### PR TITLE
Feature-35: Refactor 'store_sysmeta' to 'store_metadata'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ HashStore is a python package, and built using the [Python Poetry](https://pytho
 To install `hashstore` locally, create a virtual environment for python 3.9+, 
 install poetry, and then install or build the package with `poetry install` or `poetry build`, respectively.
 
+To run tests, navigate to the root directory and run `pytest -s`. The test suite contains tests that
+take a longer time to run (relating to the storage of large files) - to execute all tests, run
+`pytest --run-slow`. To see detailed
+
 ## License
 ```
 Copyright [2022] [Regents of the University of California]

--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -566,7 +566,7 @@ class FileHashStore(HashStore):
         )
         return True
 
-    def delete_sysmeta(self, pid):
+    def delete_metadata(self, pid, format_id):
         logging.debug(
             "FileHashStore - delete_sysmeta: Request to delete sysmeta for pid: %s",
             pid,
@@ -576,8 +576,8 @@ class FileHashStore(HashStore):
             logging.error("FileHashStore - delete_sysmeta: %s", exception_string)
             raise ValueError(exception_string)
 
-        entity = "sysmeta"
-        ab_id = self.get_sha256_hex_digest(pid)
+        entity = "metadata"
+        ab_id = self.get_sha256_hex_digest(pid + format_id)
         self.delete(entity, ab_id)
         logging.info(
             "FileHashStore - delete_sysmeta: Successfully deleted sysmeta for pid: %s",

--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -425,7 +425,7 @@ class FileHashStore(HashStore):
             )
         return hash_address
 
-    def store_metadata(self, pid, format_id=None, metadata):
+    def store_metadata(self, pid, metadata, format_id=None):
         logging.debug(
             "FileHashStore - store_metadata: Request to store metadata for pid: %s", pid
         )

--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -516,35 +516,35 @@ class FileHashStore(HashStore):
         )
         return obj_stream
 
-    def retrieve_sysmeta(self, pid):
+    def retrieve_metadata(self, pid, format_id):
         logging.debug(
-            "FileHashStore - retrieve_sysmeta: Request to retrieve sysmeta for pid: %s",
+            "FileHashStore - retrieve_metadata: Request to retrieve sysmeta for pid: %s",
             pid,
         )
         if pid is None or pid.replace(" ", "") == "":
             exception_string = f"Pid cannot be None or empty, pid: {pid}"
-            logging.error("FileHashStore - retrieve_sysmeta: %s", exception_string)
+            logging.error("FileHashStore - retrieve_metadata: %s", exception_string)
             raise ValueError(exception_string)
 
-        entity = "sysmeta"
-        ab_id = self.get_sha256_hex_digest(pid)
+        entity = "metadata"
+        ab_id = self.get_sha256_hex_digest(pid + format_id)
         sysmeta_exists = self.exists(entity, ab_id)
         if sysmeta_exists:
             logging.debug(
-                "FileHashStore - retrieve_sysmeta: Sysmeta exists for pid: %s, retrieving sysmeta.",
+                "FileHashStore - retrieve_metadata: Metadata exists for pid: %s, retrieving sysmeta.",
                 pid,
             )
-            ab_id = self.get_sha256_hex_digest(pid)
+            ab_id = self.get_sha256_hex_digest(pid + format_id)
             s_path = self.open(entity, ab_id)
             s_content = s_path.read().decode("utf-8").split("\x00", 1)
             s_path.close()
             sysmeta = s_content[1]
         else:
             exception_string = f"No sysmeta found for pid: {pid}"
-            logging.error("FileHashStore - retrieve_sysmeta: %s", exception_string)
+            logging.error("FileHashStore - retrieve_metadata: %s", exception_string)
             raise ValueError(exception_string)
         logging.info(
-            "FileHashStore - retrieve_sysmeta: Retrieved sysmeta for pid: %s", pid
+            "FileHashStore - retrieve_metadata: Retrieved metadata for pid: %s", pid
         )
         return sysmeta
 

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -103,15 +103,16 @@ class HashStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def retrieve_sysmeta(self, pid):
-        """The 'retrieve_sysmeta' method retrieves the metadata content from disk and
+    def retrieve_metadata(self, pid, format_id):
+        """The 'retrieve_metadata' method retrieves the metadata content from disk and
         returns it in the form of a String using a given persistent identifier.
 
         Args:
-            pid (string): Authority-based identifier.
+            pid (string): Authority-based identifier
+            format_id (string): Metadata format
 
         Returns:
-            sysmeta (string): Sysmeta content.
+            metadata (string): Sysmeta content.
         """
         raise NotImplementedError()
 

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -63,21 +63,23 @@ class HashStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def store_sysmeta(self, pid, sysmeta):
+    def store_metadata(self, pid, format_id, sysmeta):
         """The `store_sysmeta` method is responsible for adding and/or updating metadata
-        (`sysmeta`) to disk using a given InputStream and a persistent identifier
-        (pid). The metadata object consists of a header and body portion. The header
-        is formed by writing the namespace/format (utf-8) of the metadata document
-        followed by a null character `\x00` and the body follows immediately after.
+        (ex. `sysmeta`) to disk using a given path/stream, a persistent identifier `pid`
+        and a metadata `format_id`. The metadata object consists of a header and
+        body section, split by a null character `\x00`.
 
-        Upon successful storage of sysmeta, the method returns a String that
-        represents the file's permanent address, and similarly to 'store_object', this
-        permanent address is determined by calculating the SHA-256 hex digest of the
-        provided pid. Finally, sysmeta are stored in parallel to objects in the
-        `/store_directory/sysmeta/` directory.
+        The header contains the metadata object's permanent address, which is determined
+        by calculating the SHA-256 hex digest of the provided `pid` + `format_id`; and the
+        body contains the metadata content (ex. `sysmeta`).
+
+        Upon successful storage of sysmeta, `store_sysmeta` returns a string that
+        represents the file's permanent address. Lastly, the metadata objects are stored
+        in parallel to objects in the `/store_directory/metadata/` directory.
 
         Args:
             pid (string): Authority-based identifier.
+            format_id (string): Metadata format
             sysmeta (mixed): String or path to sysmeta document.
 
         Returns:

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -63,7 +63,7 @@ class HashStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def store_metadata(self, pid, format_id, metadata):
+    def store_metadata(self, pid, metadata, format_id):
         """The `store_metadata` method is responsible for adding and/or updating metadata
         (ex. `sysmeta`) to disk using a given path/stream, a persistent identifier `pid`
         and a metadata `format_id`. The metadata object consists of a header and a body

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -26,7 +26,7 @@ class HashStore(ABC):
         """The `store_object` method is responsible for the atomic storage of objects to
         disk using a given InputStream and a persistent identifier (pid). Upon
         successful storage, the method returns a HashAddress object containing
-        relevant file information, such as the file's id, relative path, absolute
+        relevant file information, such as the file's cid, relative path, absolute
         path, duplicate object status, and hex digest map of algorithms and
         checksums. `store_object` also ensures that an object is stored only once by
         synchronizing multiple calls and rejecting calls to store duplicate objects.

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -63,27 +63,27 @@ class HashStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def store_metadata(self, pid, format_id, sysmeta):
-        """The `store_sysmeta` method is responsible for adding and/or updating metadata
+    def store_metadata(self, pid, format_id, metadata):
+        """The `store_metadata` method is responsible for adding and/or updating metadata
         (ex. `sysmeta`) to disk using a given path/stream, a persistent identifier `pid`
-        and a metadata `format_id`. The metadata object consists of a header and
-        body section, split by a null character `\x00`.
+        and a metadata `format_id`. The metadata object consists of a header and a body
+        section, which is split by a null character `\x00`.
 
         The header contains the metadata object's permanent address, which is determined
         by calculating the SHA-256 hex digest of the provided `pid` + `format_id`; and the
         body contains the metadata content (ex. `sysmeta`).
 
-        Upon successful storage of sysmeta, `store_sysmeta` returns a string that
+        Upon successful storage of metadata, `store_metadata` returns a string that
         represents the file's permanent address. Lastly, the metadata objects are stored
         in parallel to objects in the `/store_directory/metadata/` directory.
 
         Args:
             pid (string): Authority-based identifier.
             format_id (string): Metadata format
-            sysmeta (mixed): String or path to sysmeta document.
+            metadata (mixed): String or path to metadata document.
 
         Returns:
-            sysmeta_cid (string): Address of the sysmeta document.
+            metadata_cid (string): Address of the metadata document.
         """
         raise NotImplementedError()
 

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -105,7 +105,7 @@ class HashStore(ABC):
     @abstractmethod
     def retrieve_metadata(self, pid, format_id):
         """The 'retrieve_metadata' method retrieves the metadata content from disk and
-        returns it in the form of a String using a given persistent identifier.
+        returns it in the form of a String using a given persistent identifier and format_id.
 
         Args:
             pid (string): Authority-based identifier
@@ -130,12 +130,13 @@ class HashStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def delete_sysmeta(self, pid):
-        """The 'delete_sysmeta' method deletes a metadata document (sysmeta) permanently
-        from disk using a given persistent identifier.
+    def delete_metadata(self, pid, format_id):
+        """The 'delete_metadata' method deletes a metadata document permanently
+        from disk using a given persistent identifier and format_id.
 
         Args:
-            pid (string): Authority-based identifier.
+            pid (string): Authority-based identifier
+            format_id (string): Metadata format
 
         Returns:
             boolean: `True` upon successful deletion.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def init_props(tmp_path):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "sha256",
-        "store_sysmeta_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     return properties
 
@@ -40,10 +40,14 @@ def init_store(props):
 
 @pytest.fixture(name="pids")
 def init_pids():
-    """Shared test harness data."""
+    """Shared test harness data.
+    - ab_id: the hex digest of the pid
+    - ab_format_id: the hex digest of the pid + format_id
+    """
     test_pids = {
         "doi:10.18739/A2901ZH2M": {
             "ab_id": "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e",
+            "ab_format_id": "323e0799524cec4c7e14d31289cefd884b563b5c052f154a066de5ec1e477da7",
             "md5": "db91c910a3202478c8def1071c54aae5",
             "sha1": "1fe86e3c8043afa4c70857ca983d740ad8501ccd",
             "sha224": "922b1e86f83d3ea3060fd0f7b2cf04476e8b3ddeaa3cf48c2c3cf502",
@@ -53,6 +57,7 @@ def init_pids():
         },
         "jtao.1700.1": {
             "ab_id": "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf",
+            "ab_format_id": "ddf07952ef28efc099d10d8b682480f7d2da60015f5d8873b6e1ea75b4baf689",
             "md5": "f4ea2d07db950873462a064937197b0f",
             "sha1": "3d25436c4490b08a2646e283dada5c60e5c0539d",
             "sha224": "9b3a96f434f3c894359193a63437ef86fbd5a1a1a6cc37f1d5013ac1",
@@ -62,6 +67,7 @@ def init_pids():
         },
         "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a": {
             "ab_id": "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6",
+            "ab_format_id": "9a2e08c666b728e6cbd04d247b9e556df3de5b2ca49f7c5a24868eb27cddbff2",
             "md5": "e1932fc75ca94de8b64f1d73dc898079",
             "sha1": "c6d2a69a3f5adaf478ba796c114f57b990cf7ad1",
             "sha224": "f86491d23d25dbaf7620542f056aba8a092a70be625502a6afd1fde0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,8 @@ def init_store(props):
 @pytest.fixture(name="pids")
 def init_pids():
     """Shared test harness data.
-    object_cid: hex digest of the pid
-    metadata_cid: hex digest of the pid + store_metadata_namespace
+        - object_cid: hex digest of the pid
+        - metadata_cid: hex digest of the pid + store_metadata_namespace
     """
     test_pids = {
         "doi:10.18739/A2901ZH2M": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,13 +41,13 @@ def init_store(props):
 @pytest.fixture(name="pids")
 def init_pids():
     """Shared test harness data.
-    - ab_id: the hex digest of the pid
-    - ab_format_id: the hex digest of the pid + format_id
+    object_cid: hex digest of the pid
+    metadata_cid: hex digest of the pid + store_metadata_namespace
     """
     test_pids = {
         "doi:10.18739/A2901ZH2M": {
-            "ab_id": "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e",
-            "ab_format_id": "323e0799524cec4c7e14d31289cefd884b563b5c052f154a066de5ec1e477da7",
+            "object_cid": "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e",
+            "metadata_cid": "323e0799524cec4c7e14d31289cefd884b563b5c052f154a066de5ec1e477da7",
             "md5": "db91c910a3202478c8def1071c54aae5",
             "sha1": "1fe86e3c8043afa4c70857ca983d740ad8501ccd",
             "sha224": "922b1e86f83d3ea3060fd0f7b2cf04476e8b3ddeaa3cf48c2c3cf502",
@@ -56,8 +56,8 @@ def init_pids():
             "sha512": "e9bcd6b91b102ef5803d1bd60c7a5d2dbec1a2baf5f62f7da60de07607ad6797d6a9b740d97a257fd2774f2c26503d455d8f2a03a128773477dfa96ab96a2e54",
         },
         "jtao.1700.1": {
-            "ab_id": "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf",
-            "ab_format_id": "ddf07952ef28efc099d10d8b682480f7d2da60015f5d8873b6e1ea75b4baf689",
+            "object_cid": "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf",
+            "metadata_cid": "ddf07952ef28efc099d10d8b682480f7d2da60015f5d8873b6e1ea75b4baf689",
             "md5": "f4ea2d07db950873462a064937197b0f",
             "sha1": "3d25436c4490b08a2646e283dada5c60e5c0539d",
             "sha224": "9b3a96f434f3c894359193a63437ef86fbd5a1a1a6cc37f1d5013ac1",
@@ -66,8 +66,8 @@ def init_pids():
             "sha512": "bf9e7f4d4e66bd082817d87659d1d57c2220c376cd032ed97cadd481cf40d78dd479cbed14d34d98bae8cebc603b40c633d088751f07155a94468aa59e2ad109",
         },
         "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a": {
-            "ab_id": "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6",
-            "ab_format_id": "9a2e08c666b728e6cbd04d247b9e556df3de5b2ca49f7c5a24868eb27cddbff2",
+            "object_cid": "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6",
+            "metadata_cid": "9a2e08c666b728e6cbd04d247b9e556df3de5b2ca49f7c5a24868eb27cddbff2",
             "md5": "e1932fc75ca94de8b64f1d73dc898079",
             "sha1": "c6d2a69a3f5adaf478ba796c114f57b990cf7ad1",
             "sha224": "f86491d23d25dbaf7620542f056aba8a092a70be625502a6afd1fde0",

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -467,7 +467,7 @@ def test_get_store_path_sysmeta(store):
     # pylint: disable=W0212
     path_sysmeta = store.get_store_path("sysmeta")
     path_sysmeta_string = str(path_sysmeta)
-    assert path_sysmeta_string.endswith("/metacat/sysmeta")
+    assert path_sysmeta_string.endswith("/metacat/metadata")
 
 
 def test_exists_with_absolute_path(pids, store):

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -18,7 +18,7 @@ def test_init_with_existing_hashstore_mismatched_config(store):
         "store_depth": 1,
         "store_width": 2,
         "store_algorithm": "sha256",
-        "store_sysmeta_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     with pytest.raises(ValueError):
         FileHashStore(properties)
@@ -37,7 +37,7 @@ def test_init_with_existing_hashstore_missing_yaml(store, pids):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "sha256",
-        "store_sysmeta_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     with pytest.raises(FileNotFoundError):
         FileHashStore(properties)
@@ -51,7 +51,7 @@ def test_get_properties(store):
     assert hashstore_yaml_dict.get("store_width") == 2
     assert hashstore_yaml_dict.get("store_algorithm") == "sha256"
     assert (
-        hashstore_yaml_dict.get("store_sysmeta_namespace")
+        hashstore_yaml_dict.get("store_metadata_namespace")
         == "http://ns.dataone.org/service/types/v2.0"
     )
 
@@ -70,7 +70,7 @@ def test_validate_properties(store):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "sha256",
-        "store_sysmeta_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     # pylint: disable=W0212
     assert store._validate_properties(properties)
@@ -96,7 +96,7 @@ def test_validate_properties_key_value_is_none(store):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "sha256",
-        "store_sysmeta_namespace": None,
+        "store_metadata_namespace": None,
     }
     with pytest.raises(ValueError):
         # pylint: disable=W0212
@@ -381,51 +381,54 @@ def test_mktempfile_with_unsupported_algorithm(pids, store):
         input_stream.close()
 
 
-def test_put_sysmeta_with_path(pids, store):
-    """Test put sysmeta with path object."""
-    entity = "sysmeta"
+def test_put_metadata_with_path(pids, store):
+    """Test put metadata with path object."""
+    entity = "metadata"
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
-        ab_id = store.store_sysmeta(pid, syspath)
+        ab_id = store.store_metadata(pid, format_id, syspath)
         assert store.exists(entity, ab_id)
     assert store.count(entity) == 3
 
 
-def test_put_sysmeta_with_string(pids, store):
-    """Test put sysmeta with string."""
-    entity = "sysmeta"
+def test_put_metadata_with_string(pids, store):
+    """Test put metadata with string."""
+    entity = "metadata"
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = str(Path(test_dir) / filename)
-        ab_id = store.store_sysmeta(pid, syspath)
+        ab_id = store.store_metadata(pid, format_id, syspath)
         assert store.exists(entity, ab_id)
     assert store.count(entity) == 3
 
 
-def test_put_sysmeta_ab_id(pids, store):
-    """Test put sysmeta returns correct id."""
+def test_put_metadata_ab_id(pids, store):
+    """Test put metadata returns correct id."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
-        ab_id = store.store_sysmeta(pid, syspath)
-        assert ab_id == pids[pid]["ab_id"]
+        ab_id = store.store_metadata(pid, format_id, syspath)
+        assert ab_id == pids[pid]["ab_format_id"]
 
 
-def test_mktmpsysmeta(pids, store):
-    """Test mktmpsysmeta creates tmpFile."""
+def test_mktmpmetadata(pids, store):
+    """Test mktmpmetadata creates tmpFile."""
     test_dir = "tests/testdata/"
-    entity = "sysmeta"
+    entity = "metadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         sys_stream = io.open(syspath, "rb")
-        namespace = "http://ns.dataone.org/service/types/v2.0"
+        format_id = "http://ns.dataone.org/service/types/v2.0"
         # pylint: disable=W0212
-        tmp_name = store._mktmpsysmeta(sys_stream, namespace)
+        tmp_name = store._mktmpmetadata(sys_stream, format_id)
         sys_stream.close()
         assert store.exists(entity, tmp_name)
 
@@ -462,12 +465,12 @@ def test_get_store_path_object(store):
     assert path_objects_string.endswith("/metacat/objects")
 
 
-def test_get_store_path_sysmeta(store):
-    """Check get_store_path for sysmeta path."""
+def test_get_store_path_metadata(store):
+    """Check get_store_path for metadata path."""
     # pylint: disable=W0212
-    path_sysmeta = store.get_store_path("sysmeta")
-    path_sysmeta_string = str(path_sysmeta)
-    assert path_sysmeta_string.endswith("/metacat/metadata")
+    path_metadata = store.get_store_path("metadata")
+    path_metadata_string = str(path_metadata)
+    assert path_metadata_string.endswith("/metacat/metadata")
 
 
 def test_exists_with_absolute_path(pids, store):

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -414,8 +414,8 @@ def test_put_metadata_cid(pids, store):
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
-        ab_id = store.store_metadata(pid, format_id, syspath)
-        assert ab_id == pids[pid]["metadata_cid"]
+        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        assert metadata_cid == pids[pid]["metadata_cid"]
 
 
 def test_mktmpmetadata(pids, store):

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -389,7 +389,7 @@ def test_put_metadata_with_path(pids, store):
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
-        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        metadata_cid = store.store_metadata(pid, syspath, format_id)
         assert store.exists(entity, metadata_cid)
     assert store.count(entity) == 3
 
@@ -402,7 +402,7 @@ def test_put_metadata_with_string(pids, store):
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = str(Path(test_dir) / filename)
-        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        metadata_cid = store.store_metadata(pid, syspath, format_id)
         assert store.exists(entity, metadata_cid)
     assert store.count(entity) == 3
 
@@ -414,7 +414,7 @@ def test_put_metadata_cid(pids, store):
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
-        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        metadata_cid = store.store_metadata(pid, syspath, format_id)
         assert metadata_cid == pids[pid]["metadata_cid"]
 
 

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -152,14 +152,14 @@ def test_put_object_files_stream(pids, store):
     assert store.count(entity) == 3
 
 
-def test_put_object_id(pids, store):
+def test_put_object_cid(pids, store):
     """Check put returns correct id."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         hashaddress = store.put_object(pid, path)
         hashaddress_id = hashaddress.id
-        assert hashaddress_id == pids[pid]["ab_id"]
+        assert hashaddress_id == pids[pid]["object_cid"]
 
 
 def test_put_object_relpath(pids, store):
@@ -262,8 +262,8 @@ def test_move_and_get_checksums_id(pids, store):
             _,
         ) = store._move_and_get_checksums(pid, input_stream)
         input_stream.close()
-        ab_id = store.get_sha256_hex_digest(pid)
-        assert move_id == ab_id
+        metadata_cid = store.get_sha256_hex_digest(pid)
+        assert move_id == metadata_cid
 
 
 def test_move_and_get_checksums_hex_digests(pids, store):
@@ -389,8 +389,8 @@ def test_put_metadata_with_path(pids, store):
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
-        ab_id = store.store_metadata(pid, format_id, syspath)
-        assert store.exists(entity, ab_id)
+        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        assert store.exists(entity, metadata_cid)
     assert store.count(entity) == 3
 
 
@@ -402,12 +402,12 @@ def test_put_metadata_with_string(pids, store):
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = str(Path(test_dir) / filename)
-        ab_id = store.store_metadata(pid, format_id, syspath)
-        assert store.exists(entity, ab_id)
+        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        assert store.exists(entity, metadata_cid)
     assert store.count(entity) == 3
 
 
-def test_put_metadata_ab_id(pids, store):
+def test_put_metadata_cid(pids, store):
     """Test put metadata returns correct id."""
     test_dir = "tests/testdata/"
     format_id = "http://ns.dataone.org/service/types/v2.0"
@@ -415,7 +415,7 @@ def test_put_metadata_ab_id(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         ab_id = store.store_metadata(pid, format_id, syspath)
-        assert ab_id == pids[pid]["ab_format_id"]
+        assert ab_id == pids[pid]["metadata_cid"]
 
 
 def test_mktmpmetadata(pids, store):
@@ -650,7 +650,7 @@ def test_create_path(pids, store):
     """Test makepath creates folder successfully."""
     for pid in pids:
         root_directory = store.root
-        pid_hex_digest_directory = pids[pid]["ab_id"][:2]
+        pid_hex_digest_directory = pids[pid]["metadata_cid"][:2]
         pid_directory = root_directory + pid_hex_digest_directory
         store.create_path(pid_directory)
         assert os.path.isdir(pid_directory)
@@ -708,7 +708,7 @@ def test_build_abs_path(store, pids):
         path = test_dir + pid.replace("/", "_")
         _ = store.put_object(pid, path)
         # pylint: disable=W0212
-        abs_path = store.build_abs_path(entity, pids[pid]["ab_id"])
+        abs_path = store.build_abs_path(entity, pids[pid]["object_cid"])
         assert abs_path
 
 
@@ -734,4 +734,4 @@ def test_get_sha256_hex_digest(pids, store):
     """Test for correct sha256 return value."""
     for pid in pids:
         hash_val = store.get_sha256_hex_digest(pid)
-        assert hash_val == pids[pid]["ab_id"]
+        assert hash_val == pids[pid]["object_cid"]

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -266,7 +266,31 @@ def test_store_object_checksum_correct(store):
 
 
 def test_store_object_checksum_correct_and_additional_algo(store):
-    """Test store object successfully stores with good checksum and same additional algorithm"""
+    """Test store object successfully stores with good checksum and same additional algorithm."""
+    test_dir = "tests/testdata/"
+    pid = "jtao.1700.1"
+    path = test_dir + pid
+    algorithm_additional = "sha224"
+    sha224_additional_checksum = (
+        "9b3a96f434f3c894359193a63437ef86fbd5a1a1a6cc37f1d5013ac1"
+    )
+    algorithm_checksum = "sha3_256"
+    checksum_correct = (
+        "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
+    )
+    hash_address = store.store_object(
+        pid,
+        path,
+        additional_algorithm=algorithm_additional,
+        checksum=checksum_correct,
+        checksum_algorithm=algorithm_checksum,
+    )
+    assert hash_address.hex_digests.get("sha224") == sha224_additional_checksum
+    assert hash_address.hex_digests.get("sha3_256") == checksum_correct
+
+
+def test_store_object_checksum_correct_and_additional_algo_duplicate(store):
+    """Test store object successfully stores with good checksum and same additional algorithm."""
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
@@ -298,7 +322,7 @@ def test_store_object_checksum_algorithm_empty(store):
 
 
 def test_store_object_checksum_empty(store):
-    """Test store object raises error when checksum_algorithm supplied and checksum is empty."""
+    """Test store object raises error when checksum_algorithm supplied with empty checksum."""
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
@@ -480,7 +504,7 @@ def test_store_metadata_format_id_is_none(pids, store):
 
 
 def test_store_metadata_format_id_is_custom(pids, store):
-    """Confirm default name space is used when format_id is not supplied"""
+    """Confirm new format_id is stored when default 'None' is overridden."""
     test_dir = "tests/testdata/"
     format_id = "http://hashstore.world.com/types/v1.0"
     entity = "metadata"
@@ -558,7 +582,7 @@ def test_store_metadata_pid_empty(store):
 
 
 def test_store_metadata_pid_empty_spaces(store):
-    """Test store metadata raises error with empty string."""
+    """Test store metadata raises error with empty spaces."""
     test_dir = "tests/testdata/"
     format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "   "
@@ -580,7 +604,7 @@ def test_store_metadata_format_id_empty(store):
 
 
 def test_store_metadata_pid_format_id_spaces(store):
-    """Test store metadata raises error with empty string."""
+    """Test store metadata raises error with empty spaces."""
     test_dir = "tests/testdata/"
     format_id = "       "
     pid = "jtao.1700.1"
@@ -600,7 +624,7 @@ def test_store_metadata_metadata_empty(store):
 
 
 def test_store_metadata_metadata_none(store):
-    """Test store metadata raises error with empty metadata string."""
+    """Test store metadata raises error with empty None metadata."""
     pid = "jtao.1700.1"
     format_id = "http://ns.dataone.org/service/types/v2.0"
     syspath_string = None
@@ -728,7 +752,7 @@ def test_retrieve_metadata_format_id_empty(store):
 
 
 def test_retrieve_metadata_format_id_empty_spaces(store):
-    """Test retrieve_metadata raises error when supplied with empty format_id."""
+    """Test retrieve_metadata raises error when supplied with empty spaces format_id."""
     format_id = "    "
     pid = "jtao.1700.1"
     with pytest.raises(ValueError):

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -255,14 +255,34 @@ def test_store_object_checksum_correct(store):
     entity = "objects"
     pid = "jtao.1700.1"
     path = test_dir + pid
-    algorithm_other = "sha3_256"
+    checksum_algo = "sha3_256"
     checksum_correct = (
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )
     _hash_address = store.store_object(
-        pid, path, checksum=checksum_correct, checksum_algorithm=algorithm_other
+        pid, path, checksum=checksum_correct, checksum_algorithm=checksum_algo
     )
     assert store.count(entity) == 1
+
+
+def test_store_object_checksum_correct_and_additional_algo(store):
+    """Test store object successfully stores with good checksum and same additional algorithm"""
+    test_dir = "tests/testdata/"
+    pid = "jtao.1700.1"
+    path = test_dir + pid
+    algorithm_additional = "sha3_256"
+    algorithm_checksum = "sha3_256"
+    checksum_correct = (
+        "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
+    )
+    hash_address = store.store_object(
+        pid,
+        path,
+        additional_algorithm=algorithm_additional,
+        checksum=checksum_correct,
+        checksum_algorithm=algorithm_checksum,
+    )
+    assert hash_address.hex_digests.get("sha3_256") == checksum_correct
 
 
 def test_store_object_checksum_algorithm_empty(store):

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -18,13 +18,13 @@ def test_pids_length(pids):
 
 
 def test_store_address_length(pids, store):
-    """Test store object ab_id length is 64 characters."""
+    """Test store object object_cid length is 64 characters."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         hash_address = store.store_object(pid, path)
-        ab_id = hash_address.id
-        assert len(ab_id) == 64
+        object_cid = hash_address.id
+        assert len(object_cid) == 64
 
 
 def test_store_object_files_path(pids, store):
@@ -38,7 +38,7 @@ def test_store_object_files_path(pids, store):
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
         _metadata_id = store.store_metadata(pid, format_id, syspath)
-        assert store.exists(entity, pids[pid]["ab_id"])
+        assert store.exists(entity, pids[pid]["object_cid"])
     assert store.count(entity) == 3
 
 
@@ -53,7 +53,7 @@ def test_store_object_files_string(pids, store):
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path_string)
         _metadata_id = store.store_metadata(pid, format_id, syspath)
-        assert store.exists(entity, pids[pid]["ab_id"])
+        assert store.exists(entity, pids[pid]["object_cid"])
     assert store.count(entity) == 3
 
 
@@ -66,18 +66,18 @@ def test_store_object_files_input_stream(pids, store):
         input_stream = io.open(path, "rb")
         _hash_address = store.store_object(pid, input_stream)
         input_stream.close()
-        ab_id = store.get_sha256_hex_digest(pid)
-        assert store.exists(entity, ab_id)
+        object_cid = store.get_sha256_hex_digest(pid)
+        assert store.exists(entity, object_cid)
     assert store.count(entity) == 3
 
 
 def test_store_object_id(pids, store):
-    """Test store object returns expected id (ab_id)."""
+    """Test store object returns expected id (object_cid)."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         hash_address = store.store_object(pid, path)
-        assert hash_address.id == pids[pid]["ab_id"]
+        assert hash_address.id == pids[pid]["object_cid"]
 
 
 def test_store_object_rel_path(pids, store):
@@ -86,9 +86,9 @@ def test_store_object_rel_path(pids, store):
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         hash_address = store.store_object(pid, path)
-        ab_id = pids[pid]["ab_id"]
-        ab_id_rel_path = "/".join(store.shard(ab_id))
-        assert hash_address.relpath == ab_id_rel_path
+        object_cid = pids[pid]["object_cid"]
+        object_cid_rel_path = "/".join(store.shard(object_cid))
+        assert hash_address.relpath == object_cid_rel_path
 
 
 def test_store_object_abs_path(pids, store):
@@ -97,10 +97,10 @@ def test_store_object_abs_path(pids, store):
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         hash_address = store.store_object(pid, path)
-        ab_id = pids[pid]["ab_id"]
-        ab_id_rel_path = "/".join(store.shard(ab_id))
-        ab_id_abs_path = store.objects + "/" + ab_id_rel_path
-        assert hash_address.abspath == ab_id_abs_path
+        object_cid = pids[pid]["object_cid"]
+        object_cid_rel_path = "/".join(store.shard(object_cid))
+        object_cid_abs_path = store.objects + "/" + object_cid_rel_path
+        assert hash_address.abspath == object_cid_abs_path
 
 
 def test_store_object_is_duplicate(pids, store):
@@ -196,8 +196,8 @@ def test_store_object_additional_algorithm_hyphen_uppercase(pids, store):
     hash_address = store.store_object(pid, path, algorithm_with_hyphen_and_upper)
     sha256_cid = hash_address.hex_digests.get("sha384")
     assert sha256_cid == pids[pid]["sha384"]
-    ab_id = store.get_sha256_hex_digest(pid)
-    assert store.exists(entity, ab_id)
+    object_cid = store.get_sha256_hex_digest(pid)
+    assert store.exists(entity, object_cid)
 
 
 def test_store_object_additional_algorithm_hyphen_lowercase(store):
@@ -213,8 +213,8 @@ def test_store_object_additional_algorithm_hyphen_lowercase(store):
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )
     assert additional_sha3_256_hex_digest == sha3_256_checksum
-    ab_id = store.get_sha256_hex_digest(pid)
-    assert store.exists(entity, ab_id)
+    object_cid = store.get_sha256_hex_digest(pid)
+    assert store.exists(entity, object_cid)
 
 
 def test_store_object_additional_algorithm_underscore(store):
@@ -328,8 +328,8 @@ def test_store_object_duplicate_raises_error(store):
     with pytest.raises(FileExistsError):
         _hash_address_two = store.store_object(pid, path)
     assert store.count(entity) == 1
-    ab_id = store.get_sha256_hex_digest(pid)
-    assert store.exists(entity, ab_id)
+    object_cid = store.get_sha256_hex_digest(pid)
+    assert store.exists(entity, object_cid)
 
 
 def test_store_object_duplicates_threads(store):
@@ -359,8 +359,8 @@ def test_store_object_duplicates_threads(store):
     thread3.join()
     # One thread will succeed, file count must still be 1
     assert store.count(entity) == 1
-    ab_id = store.get_sha256_hex_digest(pid)
-    assert store.exists(entity, ab_id)
+    object_cid = store.get_sha256_hex_digest(pid)
+    assert store.exists(entity, object_cid)
     assert file_exists_error_flag
 
 
@@ -421,8 +421,8 @@ def test_store_metadata_files_path(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        ab_id = store.store_metadata(pid, format_id, syspath)
-        assert store.exists(entity, ab_id)
+        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        assert store.exists(entity, metadata_cid)
     assert store.count(entity) == 3
 
 
@@ -436,8 +436,8 @@ def test_store_metadata_files_string(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath_string = str(Path(test_dir) / filename)
         _hash_address = store.store_object(pid, path_string)
-        ab_id = store.store_metadata(pid, format_id, syspath_string)
-        assert store.exists(entity, ab_id)
+        metadata_cid = store.store_metadata(pid, format_id, syspath_string)
+        assert store.exists(entity, metadata_cid)
     assert store.count(entity) == 3
 
 
@@ -452,7 +452,7 @@ def test_store_metadata_files_input_stream(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath_string = str(Path(test_dir) / filename)
         syspath_stream = io.open(syspath_string, "rb")
-        _ab_id = store.store_metadata(pid, format_id, syspath_stream)
+        _metadata_cid = store.store_metadata(pid, format_id, syspath_stream)
         syspath_stream.close()
     assert store.count(entity) == 3
 
@@ -479,6 +479,28 @@ def test_store_metadata_pid_empty_spaces(store):
         store.store_metadata(pid, format_id, syspath_string)
 
 
+def test_store_metadata_format_id_empty(store):
+    """Test store metadata raises error with empty string."""
+    test_dir = "tests/testdata/"
+    format_id = ""
+    pid = "jtao.1700.1"
+    filename = pid.replace("/", "_") + ".xml"
+    syspath_string = str(Path(test_dir) / filename)
+    with pytest.raises(ValueError):
+        store.store_metadata(pid, format_id, syspath_string)
+
+
+def test_store_metadata_pid_format_id_spaces(store):
+    """Test store metadata raises error with empty string."""
+    test_dir = "tests/testdata/"
+    format_id = "       "
+    pid = "jtao.1700.1"
+    filename = pid.replace("/", "_") + ".xml"
+    syspath_string = str(Path(test_dir) / filename)
+    with pytest.raises(ValueError):
+        store.store_metadata(pid, format_id, syspath_string)
+
+
 def test_store_metadata_metadata_empty(store):
     """Test store metadata raises error with empty metadata string."""
     pid = "jtao.1700.1"
@@ -497,8 +519,8 @@ def test_store_metadata_metadata_none(store):
         store.store_metadata(pid, format_id, syspath_string)
 
 
-def test_store_metadata_ab_id(pids, store):
-    """Test store metadata returns expected ab_id."""
+def test_store_metadata_metadata_cid(pids, store):
+    """Test store metadata returns expected metadata_cid."""
     test_dir = "tests/testdata/"
     format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
@@ -506,8 +528,8 @@ def test_store_metadata_ab_id(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        ab_id = store.store_metadata(pid, format_id, syspath)
-        assert ab_id == pids[pid]["ab_format_id"]
+        metadata_cid = store.store_metadata(pid, format_id, syspath)
+        assert metadata_cid == pids[pid]["metadata_cid"]
 
 
 def test_store_metadata_thread_lock(store):
@@ -577,7 +599,7 @@ def test_retrieve_metadata(store):
     filename = pid + ".xml"
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
-    _ab_id = store.store_metadata(pid, format_id, syspath)
+    _metadata_cid = store.store_metadata(pid, format_id, syspath)
     sysmeta_ret = store.retrieve_metadata(pid, format_id)
     sysmeta = syspath.read_bytes()
     assert sysmeta.decode("utf-8") == sysmeta_ret
@@ -610,7 +632,7 @@ def test_delete_objects(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        _ab_id = store.store_metadata(pid, format_id, syspath)
+        _metadata_cid = store.store_metadata(pid, format_id, syspath)
         store.delete_object(pid)
     assert store.count(entity) == 0
 
@@ -639,7 +661,7 @@ def test_delete_metadata(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        _ab_id = store.store_metadata(pid, format_id, syspath)
+        _metadata_cid = store.store_metadata(pid, format_id, syspath)
         store.delete_metadata(pid, format_id)
     assert store.count(entity) == 0
 
@@ -669,7 +691,7 @@ def test_get_hex_digest(store):
     filename = pid + ".xml"
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
-    _ab_id = store.store_metadata(pid, format_id, syspath)
+    _metadata_cid = store.store_metadata(pid, format_id, syspath)
     sha3_256_hex_digest = (
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -31,13 +31,14 @@ def test_store_object_files_path(pids, store):
     """Test store object when given a path."""
     test_dir = "tests/testdata/"
     entity = "objects"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = Path(test_dir + pid.replace("/", "_"))
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        ab_id = store.store_sysmeta(pid, syspath)
-        assert store.exists(entity, ab_id)
+        _metadata_id = store.store_metadata(pid, format_id, syspath)
+        assert store.exists(entity, pids[pid]["ab_id"])
     assert store.count(entity) == 3
 
 
@@ -45,13 +46,14 @@ def test_store_object_files_string(pids, store):
     """Test store object when given a string."""
     test_dir = "tests/testdata/"
     entity = "objects"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path_string = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path_string)
-        ab_id = store.store_sysmeta(pid, syspath)
-        assert store.exists(entity, ab_id)
+        _metadata_id = store.store_metadata(pid, format_id, syspath)
+        assert store.exists(entity, pids[pid]["ab_id"])
     assert store.count(entity) == 3
 
 
@@ -409,112 +411,121 @@ def test_store_object_sparse_large_file(store):
     assert hash_address_id == pid_sha256_hex_digest
 
 
-def test_store_sysmeta_files_path(pids, store):
-    """Test store sysmeta with path."""
+def test_store_metadata_files_path(pids, store):
+    """Test store metadata with path."""
     test_dir = "tests/testdata/"
-    entity = "sysmeta"
+    entity = "metadata"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        ab_id = store.store_sysmeta(pid, syspath)
+        ab_id = store.store_metadata(pid, format_id, syspath)
         assert store.exists(entity, ab_id)
     assert store.count(entity) == 3
 
 
-def test_store_sysmeta_files_string(pids, store):
-    """Test store sysmeta with string."""
+def test_store_metadata_files_string(pids, store):
+    """Test store metadata with string."""
     test_dir = "tests/testdata/"
-    entity = "sysmeta"
+    entity = "metadata"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path_string = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath_string = str(Path(test_dir) / filename)
         _hash_address = store.store_object(pid, path_string)
-        ab_id = store.store_sysmeta(pid, syspath_string)
+        ab_id = store.store_metadata(pid, format_id, syspath_string)
         assert store.exists(entity, ab_id)
     assert store.count(entity) == 3
 
 
-def test_store_sysmeta_files_input_stream(pids, store):
-    """Test store sysmeta with an input stream to sysmeta."""
+def test_store_metadata_files_input_stream(pids, store):
+    """Test store metadata with an input stream to metadata."""
     test_dir = "tests/testdata/"
-    entity = "sysmeta"
+    entity = "metadata"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         _hash_address = store.store_object(pid, path)
         filename = pid.replace("/", "_") + ".xml"
         syspath_string = str(Path(test_dir) / filename)
         syspath_stream = io.open(syspath_string, "rb")
-        _ab_id = store.store_sysmeta(pid, syspath_stream)
+        _ab_id = store.store_metadata(pid, format_id, syspath_stream)
         syspath_stream.close()
     assert store.count(entity) == 3
 
 
-def test_store_sysmeta_pid_empty(store):
-    """Test store sysmeta raises error with empty string."""
+def test_store_metadata_pid_empty(store):
+    """Test store metadata raises error with empty string."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = ""
     filename = pid.replace("/", "_") + ".xml"
     syspath_string = str(Path(test_dir) / filename)
     with pytest.raises(ValueError):
-        store.store_sysmeta(pid, syspath_string)
+        store.store_metadata(pid, format_id, syspath_string)
 
 
-def test_store_sysmeta_pid_empty_spaces(store):
-    """Test store sysmeta raises error with empty string."""
+def test_store_metadata_pid_empty_spaces(store):
+    """Test store metadata raises error with empty string."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "   "
     filename = pid.replace("/", "_") + ".xml"
     syspath_string = str(Path(test_dir) / filename)
     with pytest.raises(ValueError):
-        store.store_sysmeta(pid, syspath_string)
+        store.store_metadata(pid, format_id, syspath_string)
 
 
-def test_store_sysmeta_sysmeta_empty(store):
-    """Test store sysmeta raises error with empty sysmeta string."""
+def test_store_metadata_metadata_empty(store):
+    """Test store metadata raises error with empty metadata string."""
     pid = "jtao.1700.1"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     syspath_string = "   "
     with pytest.raises(TypeError):
-        store.store_sysmeta(pid, syspath_string)
+        store.store_metadata(pid, format_id, syspath_string)
 
 
-def test_store_sysmeta_sysmeta_none(store):
-    """Test store sysmeta raises error with empty sysmeta string."""
+def test_store_metadata_metadata_none(store):
+    """Test store metadata raises error with empty metadata string."""
     pid = "jtao.1700.1"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     syspath_string = None
     with pytest.raises(TypeError):
-        store.store_sysmeta(pid, syspath_string)
+        store.store_metadata(pid, format_id, syspath_string)
 
 
-def test_store_sysmeta_ab_id(pids, store):
-    """Test store sysmeta returns expected ab_id."""
+def test_store_metadata_ab_id(pids, store):
+    """Test store metadata returns expected ab_id."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        ab_id = store.store_sysmeta(pid, syspath)
-        assert ab_id == pids[pid]["ab_id"]
+        ab_id = store.store_metadata(pid, format_id, syspath)
+        assert ab_id == pids[pid]["ab_format_id"]
 
 
-def test_store_sysmeta_thread_lock(store):
-    """Test store sysmeta thread lock."""
+def test_store_metadata_thread_lock(store):
+    """Test store metadata thread lock."""
     test_dir = "tests/testdata/"
-    entity = "sysmeta"
+    entity = "metadata"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "jtao.1700.1"
     path = test_dir + pid
     filename = pid + ".xml"
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
-    store.store_sysmeta(pid, syspath)
+    store.store_metadata(pid, format_id, syspath)
     # Start threads
-    thread1 = Thread(target=store.store_sysmeta, args=(pid, syspath))
-    thread2 = Thread(target=store.store_sysmeta, args=(pid, syspath))
-    thread3 = Thread(target=store.store_sysmeta, args=(pid, syspath))
-    thread4 = Thread(target=store.store_sysmeta, args=(pid, syspath))
+    thread1 = Thread(target=store.store_metadata, args=(pid, format_id, syspath))
+    thread2 = Thread(target=store.store_metadata, args=(pid, format_id, syspath))
+    thread3 = Thread(target=store.store_metadata, args=(pid, format_id, syspath))
+    thread4 = Thread(target=store.store_metadata, args=(pid, format_id, syspath))
     thread1.start()
     thread2.start()
     thread3.start()
@@ -529,12 +540,13 @@ def test_store_sysmeta_thread_lock(store):
 def test_retrieve_object(pids, store):
     """Test retrieve_object returns correct object data."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         hash_address = store.store_object(pid, path)
-        store.store_sysmeta(pid, syspath)
+        store.store_metadata(pid, format_id, syspath)
         obj_stream = store.retrieve_object(pid)
         sha256_hex = store.computehash(obj_stream)
         obj_stream.close()
@@ -557,14 +569,15 @@ def test_retrieve_object_pid_invalid(store):
 
 
 def test_retrieve_sysmeta(store):
-    """Test retrieve_sysmeta returns correct sysmeta data."""
+    """Test retrieve_sysmeta returns correct metadata data."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "jtao.1700.1"
     path = test_dir + pid
     filename = pid + ".xml"
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
-    _ab_id = store.store_sysmeta(pid, syspath)
+    _ab_id = store.store_metadata(pid, format_id, syspath)
     sysmeta_ret = store.retrieve_sysmeta(pid)
     sysmeta = syspath.read_bytes()
     assert sysmeta.decode("utf-8") == sysmeta_ret
@@ -589,12 +602,13 @@ def test_delete_objects(pids, store):
     """Test delete_object successfully deletes objects."""
     test_dir = "tests/testdata/"
     entity = "objects"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        _ab_id = store.store_sysmeta(pid, syspath)
+        _ab_id = store.store_metadata(pid, format_id, syspath)
         store.delete_object(pid)
     assert store.count(entity) == 0
 
@@ -616,13 +630,14 @@ def test_delete_object_pid_none(store):
 def test_delete_sysmeta(pids, store):
     """Test delete_sysmeta successfully deletes sysmeta."""
     test_dir = "tests/testdata/"
-    entity = "sysmeta"
+    entity = "metadata"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
-        _ab_id = store.store_sysmeta(pid, syspath)
+        _ab_id = store.store_metadata(pid, format_id, syspath)
         store.delete_sysmeta(pid)
     assert store.count(entity) == 0
 
@@ -644,12 +659,13 @@ def test_delete_sysmeta_pid_none(store):
 def test_get_hex_digest(store):
     """Test get_hex_digest for expected value."""
     test_dir = "tests/testdata/"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "jtao.1700.1"
     path = test_dir + pid
     filename = pid + ".xml"
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
-    _ab_id = store.store_sysmeta(pid, syspath)
+    _ab_id = store.store_metadata(pid, format_id, syspath)
     sha3_256_hex_digest = (
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -568,8 +568,8 @@ def test_retrieve_object_pid_invalid(store):
         store.retrieve_object(pid_does_not_exist)
 
 
-def test_retrieve_sysmeta(store):
-    """Test retrieve_sysmeta returns correct metadata data."""
+def test_retrieve_metadata(store):
+    """Test retrieve_metadata returns correct metadata data."""
     test_dir = "tests/testdata/"
     format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "jtao.1700.1"
@@ -578,24 +578,26 @@ def test_retrieve_sysmeta(store):
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
     _ab_id = store.store_metadata(pid, format_id, syspath)
-    sysmeta_ret = store.retrieve_sysmeta(pid)
+    sysmeta_ret = store.retrieve_metadata(pid, format_id)
     sysmeta = syspath.read_bytes()
     assert sysmeta.decode("utf-8") == sysmeta_ret
 
 
 def test_retrieve_sysmeta_pid_invalid(store):
     """Test retrieve_sysmeta raises error when supplied with bad pid."""
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "jtao.1700.1"
     pid_does_not_exist = pid + "test"
     with pytest.raises(ValueError):
-        store.retrieve_sysmeta(pid_does_not_exist)
+        store.retrieve_metadata(pid_does_not_exist, format_id)
 
 
 def test_retrieve_sysmeta_pid_empty(store):
     """Test retrieve_sysmeta raises error when supplied with empty pid."""
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "    "
     with pytest.raises(ValueError):
-        store.retrieve_sysmeta(pid)
+        store.retrieve_metadata(pid, format_id)
 
 
 def test_delete_objects(pids, store):

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -629,8 +629,8 @@ def test_delete_object_pid_none(store):
         store.delete_object(pid)
 
 
-def test_delete_sysmeta(pids, store):
-    """Test delete_sysmeta successfully deletes sysmeta."""
+def test_delete_metadata(pids, store):
+    """Test delete_metadata successfully deletes sysmeta."""
     test_dir = "tests/testdata/"
     entity = "metadata"
     format_id = "http://ns.dataone.org/service/types/v2.0"
@@ -640,22 +640,24 @@ def test_delete_sysmeta(pids, store):
         syspath = Path(test_dir) / filename
         _hash_address = store.store_object(pid, path)
         _ab_id = store.store_metadata(pid, format_id, syspath)
-        store.delete_sysmeta(pid)
+        store.delete_metadata(pid, format_id)
     assert store.count(entity) == 0
 
 
-def test_delete_sysmeta_pid_empty(store):
+def test_delete_metadata_pid_empty(store):
     """Test delete_object raises error when empty pid supplied."""
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "    "
     with pytest.raises(ValueError):
-        store.delete_sysmeta(pid)
+        store.delete_metadata(pid, format_id)
 
 
-def test_delete_sysmeta_pid_none(store):
+def test_delete_metadata_pid_none(store):
     """Test delete_object raises error when pid is 'None'."""
+    format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = None
     with pytest.raises(ValueError):
-        store.delete_sysmeta(pid)
+        store.delete_metadata(pid, format_id)
 
 
 def test_get_hex_digest(store):


### PR DESCRIPTION
Public API method `store_sysmeta` has been refactored to `store_metadata`, along with the respective retrieve/delete methods, and all tests have been updated. 

**Notes:**
- Updated `hashstore` interface methods and descriptions
- Updated signature:
    - `store_metadata(pid, metadata, format_id)`
    - In Python, non-default argument cannot come before a default one (ex. `store_metadata(self, pid, format_id=None, metadata)`)
- When no `format_id` is supplied, we will use the default value in `hashstore.yaml`
- Successful calling of `store_sysmeta` will return the metadata_cid, which is the sha256 hex digest of the `pid + format_id`
- Documentation/comments have all been updated to distinguish between `object_cid` and `metadata_cid`