### PR TITLE
Feature-38: Metadata Public API Methods Refactor

### DIFF
--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -565,7 +565,7 @@ class FileHashStore(HashStore):
         elif format_id.replace(" ", "") == "":
             exception_string = (
                 "Format_id cannot empty, must be 'None'"
-                + "for default HashStore format or supplied."
+                + " for default HashStore format or supplied."
             )
             logging.error("FileHashStore - retrieve_metadata: %s", exception_string)
             raise ValueError(exception_string)
@@ -608,7 +608,7 @@ class FileHashStore(HashStore):
         )
         return True
 
-    def delete_metadata(self, pid, format_id):
+    def delete_metadata(self, pid, format_id=None):
         logging.debug(
             "FileHashStore - delete_metadata: Request to delete metadata for pid: %s",
             pid,
@@ -617,15 +617,21 @@ class FileHashStore(HashStore):
             exception_string = f"Pid cannot be None or empty, pid: {pid}"
             logging.error("FileHashStore - delete_metadata: %s", exception_string)
             raise ValueError(exception_string)
-        if format_id is None or format_id.replace(" ", "") == "":
+        checked_format_id = None
+        if format_id is None:
+            checked_format_id = self.sysmeta_ns
+        elif format_id.replace(" ", "") == "":
             exception_string = (
-                f"Format_id cannot be None or empty, format_id: {format_id}"
+                "Format_id cannot empty, must be 'None'"
+                + " for default HashStore format or supplied."
             )
             logging.error("FileHashStore - delete_metadata: %s", exception_string)
             raise ValueError(exception_string)
+        else:
+            checked_format_id = format_id
 
         entity = "metadata"
-        metadata_cid = self.get_sha256_hex_digest(pid + format_id)
+        metadata_cid = self.get_sha256_hex_digest(pid + checked_format_id)
         self.delete(entity, metadata_cid)
         logging.info(
             "FileHashStore - delete_metadata: Successfully deleted metadata for pid: %s",

--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -550,7 +550,7 @@ class FileHashStore(HashStore):
         )
         return obj_stream
 
-    def retrieve_metadata(self, pid, format_id):
+    def retrieve_metadata(self, pid, format_id=None):
         logging.debug(
             "FileHashStore - retrieve_metadata: Request to retrieve metadata for pid: %s",
             pid,
@@ -559,15 +559,21 @@ class FileHashStore(HashStore):
             exception_string = f"Pid cannot be None or empty, pid: {pid}"
             logging.error("FileHashStore - retrieve_metadata: %s", exception_string)
             raise ValueError(exception_string)
-        if format_id is None or format_id.replace(" ", "") == "":
+        checked_format_id = None
+        if format_id is None:
+            checked_format_id = self.sysmeta_ns
+        elif format_id.replace(" ", "") == "":
             exception_string = (
-                f"Format_id cannot be None or empty, format_id: {format_id}"
+                "Format_id cannot empty, must be 'None'"
+                + "for default HashStore format or supplied."
             )
             logging.error("FileHashStore - retrieve_metadata: %s", exception_string)
             raise ValueError(exception_string)
+        else:
+            checked_format_id = format_id
 
         entity = "metadata"
-        metadata_cid = self.get_sha256_hex_digest(pid + format_id)
+        metadata_cid = self.get_sha256_hex_digest(pid + checked_format_id)
         metadata_exists = self.exists(entity, metadata_cid)
         if metadata_exists:
             logging.debug(

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -66,12 +66,8 @@ class HashStore(ABC):
     def store_metadata(self, pid, metadata, format_id):
         """The `store_metadata` method is responsible for adding and/or updating metadata
         (ex. `sysmeta`) to disk using a given path/stream, a persistent identifier `pid`
-        and a metadata `format_id`. The metadata object consists of a header and a body
-        section, which is split by a null character `\x00`.
-
-        The header contains the metadata object's permanent address, which is determined
-        by calculating the SHA-256 hex digest of the provided `pid` + `format_id`; and the
-        body contains the metadata content (ex. `sysmeta`).
+        and a metadata `format_id`. The metadata object's permanent address, which is
+        determined by calculating the SHA-256 hex digest of the provided `pid` + `format_id`.
 
         Upon successful storage of metadata, `store_metadata` returns a string that
         represents the file's permanent address. Lastly, the metadata objects are stored
@@ -98,7 +94,7 @@ class HashStore(ABC):
             pid (string): Authority-based identifier.
 
         Returns:
-            obj_stream (io.BufferedReader): A buffered stream of an ab_id object.
+            obj_stream (io.BufferedReader): A buffered stream of a data object.
         """
         raise NotImplementedError()
 
@@ -112,7 +108,7 @@ class HashStore(ABC):
             format_id (string): Metadata format
 
         Returns:
-            metadata (string): Sysmeta content.
+            metadata_stream (io.BufferedReader): A buffered stream of a metadata object.
         """
         raise NotImplementedError()
 

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -505,7 +505,6 @@ def test_mktempmetadata(pids, store):
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
         sys_stream = io.open(syspath, "rb")
-        format_id = "http://ns.dataone.org/service/types/v2.0"
         # pylint: disable=W0212
         tmp_name = store._mktempmetadata(sys_stream)
         sys_stream.close()

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -507,7 +507,7 @@ def test_mktempmetadata(pids, store):
         sys_stream = io.open(syspath, "rb")
         format_id = "http://ns.dataone.org/service/types/v2.0"
         # pylint: disable=W0212
-        tmp_name = store._mktempmetadata(sys_stream, format_id)
+        tmp_name = store._mktempmetadata(sys_stream)
         sys_stream.close()
         assert store.exists(entity, tmp_name)
 

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -484,7 +484,7 @@ def test_store_metadata(pids, store):
 
 
 def test_store_metadata_default_format_id(pids, store):
-    """Test store metadata returns expected id when storing with default format_id"""
+    """Test store metadata returns expected id when storing with default format_id."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
@@ -682,7 +682,7 @@ def test_retrieve_metadata(store):
 
 
 def test_retrieve_metadata_default_format_id(store):
-    """Test retrieve_metadata retrieves expected metadata when format_id is none"""
+    """Test retrieve_metadata retrieves expected metadata with default format_id."""
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
@@ -774,6 +774,20 @@ def test_delete_metadata(pids, store):
     assert store.count(entity) == 0
 
 
+def test_delete_metadata_default_format_id(store, pids):
+    """Test delete_metadata deletes successfully with default format_id."""
+    test_dir = "tests/testdata/"
+    entity = "metadata"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        filename = pid.replace("/", "_") + ".xml"
+        syspath = Path(test_dir) / filename
+        _hash_address = store.store_object(pid, path)
+        _metadata_cid = store.store_metadata(pid, syspath)
+        store.delete_metadata(pid)
+    assert store.count(entity) == 0
+
+
 def test_delete_metadata_pid_empty(store):
     """Test delete_object raises error when empty pid supplied."""
     format_id = "http://ns.dataone.org/service/types/v2.0"
@@ -793,14 +807,6 @@ def test_delete_metadata_pid_none(store):
 def test_delete_metadata_format_id_empty(store):
     """Test delete_object raises error when empty format_id supplied."""
     format_id = "    "
-    pid = "jtao.1700.1"
-    with pytest.raises(ValueError):
-        store.delete_metadata(pid, format_id)
-
-
-def test_delete_metadata_format_id_none(store):
-    """Test delete_object raises error when format_id is 'None'."""
-    format_id = None
     pid = "jtao.1700.1"
     with pytest.raises(ValueError):
         store.delete_metadata(pid, format_id)

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -483,6 +483,18 @@ def test_store_metadata(pids, store):
         assert metadata_cid == pids[pid]["metadata_cid"]
 
 
+def test_store_metadata_default_format_id(pids, store):
+    """Test store metadata returns expected id when storing with default format_id"""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        filename = pid.replace("/", "_") + ".xml"
+        syspath = Path(test_dir) / filename
+        _hash_address = store.store_object(pid, path)
+        metadata_cid = store.store_metadata(pid, syspath)
+        assert metadata_cid == pids[pid]["metadata_cid"]
+
+
 def test_store_metadata_files_path(pids, store):
     """Test store metadata with path."""
     test_dir = "tests/testdata/"
@@ -546,17 +558,6 @@ def test_store_metadata_pid_empty_spaces(store):
     test_dir = "tests/testdata/"
     format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "   "
-    filename = pid.replace("/", "_") + ".xml"
-    syspath_string = str(Path(test_dir) / filename)
-    with pytest.raises(ValueError):
-        store.store_metadata(pid, syspath_string, format_id)
-
-
-def test_store_metadata_format_id_empty(store):
-    """Test store metadata raises error with empty string."""
-    test_dir = "tests/testdata/"
-    format_id = ""
-    pid = "jtao.1700.1"
     filename = pid.replace("/", "_") + ".xml"
     syspath_string = str(Path(test_dir) / filename)
     with pytest.raises(ValueError):
@@ -680,6 +681,22 @@ def test_retrieve_metadata(store):
     assert metadata.decode("utf-8") == metadata_content
 
 
+def test_retrieve_metadata_default_format_id(store):
+    """Test retrieve_metadata retrieves expected metadata when format_id is none"""
+    test_dir = "tests/testdata/"
+    pid = "jtao.1700.1"
+    path = test_dir + pid
+    filename = pid + ".xml"
+    syspath = Path(test_dir) / filename
+    _hash_address = store.store_object(pid, path)
+    _metadata_cid = store.store_metadata(pid, syspath)
+    metadata_stream = store.retrieve_metadata(pid)
+    metadata_content = metadata_stream.read().decode("utf-8")
+    metadata_stream.close()
+    metadata = syspath.read_bytes()
+    assert metadata.decode("utf-8") == metadata_content
+
+
 def test_retrieve_metadata_bytes_pid_invalid(store):
     """Test retrieve_metadata raises error when supplied with bad pid."""
     format_id = "http://ns.dataone.org/service/types/v2.0"
@@ -693,14 +710,6 @@ def test_retrieve_metadata_bytes_pid_empty(store):
     """Test retrieve_metadata raises error when supplied with empty pid."""
     format_id = "http://ns.dataone.org/service/types/v2.0"
     pid = "    "
-    with pytest.raises(ValueError):
-        store.retrieve_metadata(pid, format_id)
-
-
-def test_retrieve_metadata_format_id_none(store):
-    """Test retrieve_metadata raises error when supplied with None format_id"""
-    format_id = None
-    pid = "jtao.1700.1"
     with pytest.raises(ValueError):
         store.retrieve_metadata(pid, format_id)
 

--- a/tests/filehashstore/test_filehashstore_interface.py
+++ b/tests/filehashstore/test_filehashstore_interface.py
@@ -483,46 +483,6 @@ def test_store_metadata(pids, store):
         assert metadata_cid == pids[pid]["metadata_cid"]
 
 
-def test_store_metadata_format_id_is_none(pids, store):
-    """Confirm default name space is used when format_id is not supplied"""
-    test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
-    entity = "metadata"
-    for pid in pids.keys():
-        path = test_dir + pid.replace("/", "_")
-        filename = pid.replace("/", "_") + ".xml"
-        syspath = Path(test_dir) / filename
-        _hash_address = store.store_object(pid, path)
-        metadata_cid = store.store_metadata(pid, syspath)
-        metadata_cid_stream = store.open(entity, metadata_cid)
-        metadata_cid_content = (
-            metadata_cid_stream.read().decode("utf-8").split("\x00", 1)
-        )
-        metadata_cid_stream.close()
-        metadata_format = metadata_cid_content[0]
-        assert metadata_format == format_id
-
-
-def test_store_metadata_format_id_is_custom(pids, store):
-    """Confirm new format_id is stored when default 'None' is overridden."""
-    test_dir = "tests/testdata/"
-    format_id = "http://hashstore.world.com/types/v1.0"
-    entity = "metadata"
-    for pid in pids.keys():
-        path = test_dir + pid.replace("/", "_")
-        filename = pid.replace("/", "_") + ".xml"
-        syspath = Path(test_dir) / filename
-        _hash_address = store.store_object(pid, path)
-        metadata_cid = store.store_metadata(pid, syspath, format_id)
-        metadata_cid_stream = store.open(entity, metadata_cid)
-        metadata_cid_content = (
-            metadata_cid_stream.read().decode("utf-8").split("\x00", 1)
-        )
-        metadata_cid_stream.close()
-        metadata_format = metadata_cid_content[0]
-        assert metadata_format == format_id
-
-
 def test_store_metadata_files_path(pids, store):
     """Test store metadata with path."""
     test_dir = "tests/testdata/"
@@ -713,9 +673,11 @@ def test_retrieve_metadata(store):
     syspath = Path(test_dir) / filename
     _hash_address = store.store_object(pid, path)
     _metadata_cid = store.store_metadata(pid, syspath, format_id)
-    metadata_bytes = store.retrieve_metadata(pid, format_id)
+    metadata_stream = store.retrieve_metadata(pid, format_id)
+    metadata_content = metadata_stream.read().decode("utf-8")
+    metadata_stream.close()
     metadata = syspath.read_bytes()
-    assert metadata.decode("utf-8") == metadata_bytes
+    assert metadata.decode("utf-8") == metadata_content
 
 
 def test_retrieve_metadata_bytes_pid_invalid(store):


### PR DESCRIPTION
Summary of Changes:
- Refactored `store_metadata()` to only store supplied metadata content (no more header)
- Refactored `retrieve_metadata()` to return a stream of the metadata content rather than a string
- Updated `store_metadata()`, `retrieve_metadata()` and `delete_metadata()` to use Hashstore's default metadata namespace/format_id when `format_id` is not supplied.
- Update `hashstore.py` interface doc strings