### PR TITLE
Bugfix-42: Store Algorithm

### DIFF
--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -86,6 +86,8 @@ class FileHashStore(HashStore):
             # If no exceptions thrown, FileHashStore ready for initialization
             logging.debug("FileHashStore - Initializing, properties verified.")
             self.root = prop_store_path
+            if not os.path.exists(self.root):
+                self.create_path(self.root)
             self.depth = prop_store_depth
             self.width = prop_store_width
             self.algorithm = prop_store_algorithm
@@ -103,8 +105,6 @@ class FileHashStore(HashStore):
             # Complete initialization/instantiation by setting and creating store directories
             self.objects = self.root + "/objects"
             self.metadata = self.root + "/metadata"
-            if not os.path.exists(self.root):
-                self.create_path(self.root)
             if not os.path.exists(self.objects):
                 self.create_path(self.objects + "/tmp")
             if not os.path.exists(self.metadata):
@@ -188,6 +188,16 @@ class FileHashStore(HashStore):
             checked_properties[property_name]
             for property_name in self.property_required_keys
         ]
+
+        # Standardize algorithm value for cross-language compatibility
+        dataone_algo_translation = {
+            "md5": "MD5",
+            "sha1": "SHA-1",
+            "sha256": "SHA-256",
+            "sha384": "SHA-384",
+            "sha512": "SHA-512",
+        }
+        store_algorithm = dataone_algo_translation[store_algorithm]
 
         # .yaml file to write
         hashstore_configuration_yaml = self._build_hashstore_yaml_string(
@@ -293,7 +303,7 @@ class FileHashStore(HashStore):
                     exception_string = (
                         f"FileHashStore - Given properties ({key}: {properties[key]}) does not"
                         + f" match. HashStore configuration ({key}: {hashstore_yaml_dict[key]})"
-                        + f"found at: {self.hashstore_configuration_yaml}"
+                        + f" found at: {self.hashstore_configuration_yaml}"
                     )
                     logging.critical(exception_string)
                     raise ValueError(exception_string)

--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -169,7 +169,7 @@ class FileHashStore(HashStore):
         # If hashstore.yaml already exists, must throw exception and proceed with caution
         if os.path.exists(self.hashstore_configuration_yaml):
             exception_string = (
-                "FileHashStore - put_properties: configuration file 'hashstore.yaml'"
+                "FileHashStore - write_properties: configuration file 'hashstore.yaml'"
                 + " already exists."
             )
             logging.error(exception_string)
@@ -190,21 +190,32 @@ class FileHashStore(HashStore):
         ]
 
         # Standardize algorithm value for cross-language compatibility
-        dataone_algo_translation = {
+        checked_store_algoritm = None
+        # Note, this must be declared here because HashStore has not yet been initialized
+        accepted_store_algorithms = {
             "md5": "MD5",
             "sha1": "SHA-1",
             "sha256": "SHA-256",
             "sha384": "SHA-384",
             "sha512": "SHA-512",
         }
-        store_algorithm = dataone_algo_translation[store_algorithm]
+        if store_algorithm in accepted_store_algorithms:
+            checked_store_algoritm = accepted_store_algorithms[store_algorithm]
+        else:
+            exception_string = (
+                "FileHashStore - write_properties: algorithm supplied cannot"
+                + " be used as default for HashStore. Must be one of:"
+                + " md5, sha1, sha256, sha384, sha512"
+            )
+            logging.error(exception_string)
+            raise ValueError(exception_string)
 
         # .yaml file to write
         hashstore_configuration_yaml = self._build_hashstore_yaml_string(
             store_path,
             store_depth,
             store_width,
-            store_algorithm,
+            checked_store_algoritm,
             store_metadata_namespace,
         )
         # Write 'hashstore.yaml'
@@ -214,7 +225,7 @@ class FileHashStore(HashStore):
             hashstore_yaml.write(hashstore_configuration_yaml)
 
         logging.debug(
-            "FileHashStore - put_properties: Configuration file written to: %s",
+            "FileHashStore - write_properties: Configuration file written to: %s",
             self.hashstore_configuration_yaml,
         )
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,8 @@ def init_store(props):
 @pytest.fixture(name="pids")
 def init_pids():
     """Shared test harness data.
-        - object_cid: hex digest of the pid
-        - metadata_cid: hex digest of the pid + store_metadata_namespace
+    - object_cid: hex digest of the pid
+    - metadata_cid: hex digest of the pid + store_metadata_namespace
     """
     test_pids = {
         "doi:10.18739/A2901ZH2M": {

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -63,7 +63,9 @@ def test_load_properties(store):
     assert hashstore_yaml_dict.get("store_path") == store.root
     assert hashstore_yaml_dict.get("store_depth") == 3
     assert hashstore_yaml_dict.get("store_width") == 2
-    assert hashstore_yaml_dict.get("store_algorithm") == "sha256"
+    # Note, the store_algorithm from `hashstore.yaml` gets translated to a standardized value
+    # Ex. "sha256" is supplied but is written into the file as "SHA-256"
+    assert hashstore_yaml_dict.get("store_algorithm") == "SHA-256"
     assert (
         hashstore_yaml_dict.get("store_metadata_namespace")
         == "http://ns.dataone.org/service/types/v2.0"

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -1,5 +1,6 @@
 """Test module for HashStore (and HashStoreFactory)"""
 import pytest
+import os
 from hashstore.filehashstore.filehashstore import FileHashStore
 from hashstore.hashstore_factory import HashStoreFactory
 
@@ -39,3 +40,19 @@ def test_factory_get_hashstore_unsupported_module(factory):
         module_name = "hashstore.s3filestore.s3filestore"
         class_name = "FileHashStore"
         factory.get_hashstore(module_name, class_name)
+
+
+def test_factory_get_hashstore_filehashstore_unsupported_algorithm(factory):
+    """Check factory creates instance of FileHashStore."""
+    module_name = "hashstore.filehashstore.filehashstore"
+    class_name = "FileHashStore"
+
+    properties = {
+        "store_path": os.getcwd() + "/metacat/test",
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "md2",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    with pytest.raises(ValueError):
+        factory.get_hashstore(module_name, class_name, properties)


### PR DESCRIPTION
Summary of Changes:
- `FileHashStore` checks that a given store algorithm is part of the default list before writing `hashstore.yaml` config file
- Store algorithm value to be written in `hashstore.yaml` now gets standardized to the DataONE controlled algorithms for cross-language compatibility