### PR TITLE
Bugfix-50: Standardize HashStore Initialization Store Algorithm

### DIFF
--- a/src/hashstore/filehashstore/filehashstore.py
+++ b/src/hashstore/filehashstore/filehashstore.py
@@ -192,20 +192,15 @@ class FileHashStore(HashStore):
         # Standardize algorithm value for cross-language compatibility
         checked_store_algoritm = None
         # Note, this must be declared here because HashStore has not yet been initialized
-        accepted_store_algorithms = {
-            "md5": "MD5",
-            "sha1": "SHA-1",
-            "sha256": "SHA-256",
-            "sha384": "SHA-384",
-            "sha512": "SHA-512",
-        }
+        accepted_store_algorithms = ["MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512"]
         if store_algorithm in accepted_store_algorithms:
-            checked_store_algoritm = accepted_store_algorithms[store_algorithm]
+            checked_store_algoritm = store_algorithm
         else:
             exception_string = (
                 "FileHashStore - write_properties: algorithm supplied cannot"
                 + " be used as default for HashStore. Must be one of:"
-                + " md5, sha1, sha256, sha384, sha512"
+                + " MD5, SHA-1, SHA-256, SHA-384, SHA-512 which are DataONE"
+                + " controlled algorithm values"
             )
             logging.error(exception_string)
             raise ValueError(exception_string)
@@ -395,6 +390,7 @@ class FileHashStore(HashStore):
         with open(self.hashstore_configuration_yaml, "r", encoding="utf-8") as file:
             yaml_data = yaml.safe_load(file)
 
+        # Takes DataOne controlled algorithm values and translates to hashlib supported values
         yaml_store_default_algo_list = yaml_data["store_default_algo_list"]
         translated_default_algo_list = []
         for algo in yaml_store_default_algo_list:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def init_props(tmp_path):
         "store_path": hashstore_path,
         "store_depth": 3,
         "store_width": 2,
-        "store_algorithm": "sha256",
+        "store_algorithm": "SHA-256",
         "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     return properties

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -76,7 +76,7 @@ def test_init_with_existing_hashstore_missing_yaml(store, pids):
         "store_path": store.root,
         "store_depth": 3,
         "store_width": 2,
-        "store_algorithm": "sha256",
+        "store_algorithm": "SHA-256",
         "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     with pytest.raises(FileNotFoundError):
@@ -90,7 +90,7 @@ def test_load_properties(store):
     assert hashstore_yaml_dict.get("store_depth") == 3
     assert hashstore_yaml_dict.get("store_width") == 2
     # Note, the store_algorithm from `hashstore.yaml` gets translated to a standardized value
-    # Ex. "sha256" is supplied but is written into the file as "SHA-256"
+    # Ex. "SHA-256" is supplied but is written into the file as "SHA-256"
     assert hashstore_yaml_dict.get("store_algorithm") == "SHA-256"
     assert (
         hashstore_yaml_dict.get("store_metadata_namespace")
@@ -111,7 +111,7 @@ def test_validate_properties(store):
         "store_path": "/etc/test",
         "store_depth": 3,
         "store_width": 2,
-        "store_algorithm": "sha256",
+        "store_algorithm": "SHA-256",
         "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     # pylint: disable=W0212
@@ -124,7 +124,7 @@ def test_validate_properties_missing_key(store):
         "store_path": "/etc/test",
         "store_depth": 3,
         "store_width": 2,
-        "store_algorithm": "sha256",
+        "store_algorithm": "SHA-256",
     }
     with pytest.raises(KeyError):
         # pylint: disable=W0212
@@ -137,7 +137,7 @@ def test_validate_properties_key_value_is_none(store):
         "store_path": "/etc/test",
         "store_depth": 3,
         "store_width": 2,
-        "store_algorithm": "sha256",
+        "store_algorithm": "SHA-256",
         "store_metadata_namespace": None,
     }
     with pytest.raises(ValueError):

--- a/tests/filehashstore/test_filehashstore.py
+++ b/tests/filehashstore/test_filehashstore.py
@@ -20,6 +20,32 @@ def test_init_directories_created(store):
     assert os.path.exists(store.metadata + "/tmp")
 
 
+def test_init_existing_store_incorrect_algorithm_format(store):
+    """Confirm that exception is thrown when store_algorithm is not a DataONE controlled value"""
+    properties = {
+        "store_path": store.root,
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "sha256",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    with pytest.raises(ValueError):
+        FileHashStore(properties)
+
+
+def test_init_existing_store_correct_algorithm_format(store):
+    """Confirm second instance of HashStore with DataONE controlled value"""
+    properties = {
+        "store_path": store.root,
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "SHA-256",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    hashstore_instance = FileHashStore(properties)
+    assert isinstance(hashstore_instance, FileHashStore)
+
+
 def test_init_write_properties_hashstore_yaml_exists(store):
     """Verify properties file present in store root directory."""
     assert os.path.exists(store.hashstore_configuration_yaml)

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -43,7 +43,7 @@ def test_factory_get_hashstore_unsupported_module(factory):
 
 
 def test_factory_get_hashstore_filehashstore_unsupported_algorithm(factory):
-    """Check factory creates instance of FileHashStore."""
+    """Check factory raises exception with store algorithm value that part of the default list"""
     module_name = "hashstore.filehashstore.filehashstore"
     class_name = "FileHashStore"
 
@@ -52,6 +52,22 @@ def test_factory_get_hashstore_filehashstore_unsupported_algorithm(factory):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "md2",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    with pytest.raises(ValueError):
+        factory.get_hashstore(module_name, class_name, properties)
+
+
+def test_factory_get_hashstore_filehashstore_incorrect_algorithm_format(factory):
+    """Check factory raises exception with incorrectly formatted algorithm value"""
+    module_name = "hashstore.filehashstore.filehashstore"
+    class_name = "FileHashStore"
+
+    properties = {
+        "store_path": os.getcwd() + "/metacat/test",
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "sha256",
         "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     with pytest.raises(ValueError):


### PR DESCRIPTION
Summary of Changes:
- HashStore now requires a DataONE controlled algorithm value to initialize
- Added new pytests
- Confirmed `--run-slow` tests successfully executed