### PR TITLE
Feature-46: Refactor HashAddress (ObjectMetadata)

### DIFF
--- a/src/hashstore/__init__.py
+++ b/src/hashstore/__init__.py
@@ -15,6 +15,6 @@ processes that function across a cluster environment. Some properties:
     their persistent identifier (PID)
 """
 
-from hashstore.hashstore import HashStore, HashStoreFactory, HashAddress
+from hashstore.hashstore import HashStore, HashStoreFactory, ObjectMetadata
 
-__all__ = ("HashStore", "HashAddress", "HashStoreFactory")
+__all__ = ("HashStore", "ObjectMetadata", "HashStoreFactory")

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -740,7 +740,7 @@ class FileHashStore(HashStore):
             + f" file and calculating checksums for pid: {pid}"
         )
         logging.debug(debug_msg)
-        hex_digests, tmp_file_name, tmp_file_size = self._mktempfile(
+        hex_digests, tmp_file_name, tmp_file_size = self._mktmpfile(
             stream, additional_algorithm, checksum_algorithm
         )
         logging.debug(
@@ -823,7 +823,7 @@ class FileHashStore(HashStore):
 
         return (object_cid, tmp_file_size, is_object_duplicate, hex_digests)
 
-    def _mktempfile(self, stream, additional_algorithm=None, checksum_algorithm=None):
+    def _mktmpfile(self, stream, additional_algorithm=None, checksum_algorithm=None):
         """Create a named temporary file from a `Stream` object and return its filename
         and a dictionary of its algorithms and hex digests. If an additionak and/or checksum
         algorithm is provided, it will add the respective hex digest to the dictionary.
@@ -903,7 +903,7 @@ class FileHashStore(HashStore):
         # Create metadata tmp file and write to it
         metadata_stream = Stream(metadata)
         with closing(metadata_stream):
-            metadata_tmp = self._mktempmetadata(metadata_stream)
+            metadata_tmp = self._mktmpmetadata(metadata_stream)
 
         # Get target and related paths (permanent location)
         metadata_cid = self.get_sha256_hex_digest(pid + format_id)
@@ -943,7 +943,7 @@ class FileHashStore(HashStore):
             logging.error(exception_string)
             raise FileNotFoundError(exception_string)
 
-    def _mktempmetadata(self, stream):
+    def _mktmpmetadata(self, stream):
         """Create a named temporary file with `stream` (metadata) and `format_id`.
 
         Args:

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from contextlib import closing
 from tempfile import NamedTemporaryFile
 import yaml
-from hashstore import HashStore, HashAddress
+from hashstore import HashStore, ObjectMetadata
 
 
 class FileHashStore(HashStore):
@@ -674,7 +674,7 @@ class FileHashStore(HashStore):
                 checksum_algorithm,
             )
 
-        hash_address = HashAddress(
+        hash_address = ObjectMetadata(
             object_cid, rel_path, abs_path, is_duplicate, hex_digest_dict
         )
         logging.debug(

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -58,8 +58,8 @@ class HashStore(ABC):
             checksum_algorithm (string): Algorithm of supplied checksum.
 
         Returns:
-            address (HashAddress): Object that contains the permanent address, relative
-            file path, absolute file path, duplicate file boolean and hex digest dictionary.
+            object_metadata (ObjectMetadata): Object that contains the permanent address,
+            file size, duplicate file boolean and hex digest dictionary.
         """
         raise NotImplementedError()
 
@@ -209,16 +209,13 @@ class HashStoreFactory:
 
 
 class ObjectMetadata(
-    namedtuple(
-        "HashAddress", ["id", "relpath", "abspath", "is_duplicate", "hex_digests"]
-    )
+    namedtuple("ObjectMetadata", ["id", "obj_size", "is_duplicate", "hex_digests"])
 ):
     """File address containing file's path on disk and its content hash ID.
 
     Args:
         ab_id (str): Hash ID (hexdigest) of file contents.
-        relpath (str): Relative path location to :attr:`HashFS.root`.
-        abspath (str): Absolute path location of file on disk.
+        obj_size (bytes): Size of the object
         is_duplicate (boolean, optional): Whether the hash address created was
             a duplicate of a previously existing file. Can only be ``True``
             after a put operation. Defaults to ``False``.
@@ -227,7 +224,7 @@ class ObjectMetadata(
     """
 
     # Default value to prevent dangerous default value
-    def __new__(cls, ab_id, relpath, abspath, is_duplicate=False, hex_digests=None):
+    def __new__(cls, ab_id, obj_size, is_duplicate=False, hex_digests=None):
         return super(ObjectMetadata, cls).__new__(
-            cls, ab_id, relpath, abspath, is_duplicate, hex_digests
+            cls, ab_id, obj_size, is_duplicate, hex_digests
         )

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -23,6 +23,7 @@ class HashStore(ABC):
         additional_algorithm,
         checksum,
         checksum_algorithm,
+        expected_object_size,
     ):
         """The `store_object` method is responsible for the atomic storage of objects to
         disk using a given InputStream and a persistent identifier (pid). Upon
@@ -46,8 +47,8 @@ class HashStore(ABC):
         with its corresponding hex digest. An algorithm is considered "supported" if it
         is recognized as a valid hash algorithm in the `hashlib` library.
 
-        Similarly, if a checksum and a checksumAlgorithm value are provided,
-        `store_object` validates the object to ensure it matches what is provided
+        Similarly, if a file size and/or checksum & checksumAlgorithm value are provided,
+        `store_object` validates the object to ensure it matches the given arguments
         before moving the file to its permanent address.
 
         Args:
@@ -56,6 +57,7 @@ class HashStore(ABC):
             additional_algorithm (string): Additional hex digest to include.
             checksum (string): Checksum to validate against.
             checksum_algorithm (string): Algorithm of supplied checksum.
+            expected_object_size (int): Size of object to verify
 
         Returns:
             object_metadata (ObjectMetadata): Object that contains the permanent address,

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -208,7 +208,7 @@ class HashStoreFactory:
         )
 
 
-class HashAddress(
+class ObjectMetadata(
     namedtuple(
         "HashAddress", ["id", "relpath", "abspath", "is_duplicate", "hex_digests"]
     )
@@ -228,6 +228,6 @@ class HashAddress(
 
     # Default value to prevent dangerous default value
     def __new__(cls, ab_id, relpath, abspath, is_duplicate=False, hex_digests=None):
-        return super(HashAddress, cls).__new__(
+        return super(ObjectMetadata, cls).__new__(
             cls, ab_id, relpath, abspath, is_duplicate, hex_digests
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def init_pids():
     """
     test_pids = {
         "doi:10.18739/A2901ZH2M": {
+            "file_size_bytes": 39993,
             "object_cid": "0d555ed77052d7e166017f779cbc193357c3a5006ee8b8457230bcf7abcef65e",
             "metadata_cid": "323e0799524cec4c7e14d31289cefd884b563b5c052f154a066de5ec1e477da7",
             "md5": "db91c910a3202478c8def1071c54aae5",
@@ -56,6 +57,7 @@ def init_pids():
             "sha512": "e9bcd6b91b102ef5803d1bd60c7a5d2dbec1a2baf5f62f7da60de07607ad6797d6a9b740d97a257fd2774f2c26503d455d8f2a03a128773477dfa96ab96a2e54",
         },
         "jtao.1700.1": {
+            "file_size_bytes": 8724,
             "object_cid": "a8241925740d5dcd719596639e780e0a090c9d55a5d0372b0eaf55ed711d4edf",
             "metadata_cid": "ddf07952ef28efc099d10d8b682480f7d2da60015f5d8873b6e1ea75b4baf689",
             "md5": "f4ea2d07db950873462a064937197b0f",
@@ -66,6 +68,7 @@ def init_pids():
             "sha512": "bf9e7f4d4e66bd082817d87659d1d57c2220c376cd032ed97cadd481cf40d78dd479cbed14d34d98bae8cebc603b40c633d088751f07155a94468aa59e2ad109",
         },
         "urn:uuid:1b35d0a5-b17a-423b-a2ed-de2b18dc367a": {
+            "file_size_bytes": 18699,
             "object_cid": "7f5cc18f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6",
             "metadata_cid": "9a2e08c666b728e6cbd04d247b9e556df3de5b2ca49f7c5a24868eb27cddbff2",
             "md5": "e1932fc75ca94de8b64f1d73dc898079",

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -172,9 +172,9 @@ def test_put_object_files_path(pids, store):
     entity = "objects"
     for pid in pids.keys():
         path = Path(test_dir) / pid.replace("/", "_")
-        hash_address = store.put_object(pid, path)
-        hashaddress_id = hash_address.id
-        assert store.exists(entity, hashaddress_id)
+        object_metadata = store.put_object(pid, path)
+        object_metadata_id = object_metadata.id
+        assert store.exists(entity, object_metadata_id)
 
 
 def test_put_object_files_string(pids, store):
@@ -183,9 +183,9 @@ def test_put_object_files_string(pids, store):
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hash_address = store.put_object(pid, path)
-        hashaddress_id = hash_address.id
-        assert store.exists(entity, hashaddress_id)
+        object_metadata = store.put_object(pid, path)
+        object_metadata_id = object_metadata.id
+        assert store.exists(entity, object_metadata_id)
 
 
 def test_put_object_files_stream(pids, store):
@@ -195,10 +195,10 @@ def test_put_object_files_stream(pids, store):
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         input_stream = io.open(path, "rb")
-        hash_address = store.put_object(pid, input_stream)
+        object_metadata = store.put_object(pid, input_stream)
         input_stream.close()
-        hashaddress_id = hash_address.id
-        assert store.exists(entity, hashaddress_id)
+        object_metadata_id = object_metadata.id
+        assert store.exists(entity, object_metadata_id)
     assert store.count(entity) == 3
 
 
@@ -207,34 +207,19 @@ def test_put_object_cid(pids, store):
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_id = hashaddress.id
-        assert hashaddress_id == pids[pid]["object_cid"]
+        object_metadata = store.put_object(pid, path)
+        object_metadata_id = object_metadata.id
+        assert object_metadata_id == pids[pid]["object_cid"]
 
 
-def test_put_object_relpath(pids, store):
-    """Check put returns correct relative path."""
+def test_put_object_file_size(pids, store):
+    """Check put returns correct file size."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_id = hashaddress.id
-        hashaddress_relpath = hashaddress.relpath
-        shard_id_path = "/".join(store.shard(hashaddress_id))
-        assert hashaddress_relpath == shard_id_path
-
-
-def test_put_object_abspath(pids, store):
-    """Check put returns correct absolute path."""
-    test_dir = "tests/testdata/"
-    entity = "objects"
-    for pid in pids.keys():
-        path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_id = hashaddress.id
-        hashaddress_abspath = hashaddress.abspath
-        id_abs_path = store.get_real_path(entity, hashaddress_id)
-        assert hashaddress_abspath == id_abs_path
+        object_metadata = store.put_object(pid, path)
+        object_size = object_metadata.obj_size
+        assert object_size == pids[pid]["file_size_bytes"]
 
 
 def test_put_object_is_duplicate(pids, store):
@@ -242,9 +227,9 @@ def test_put_object_is_duplicate(pids, store):
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_is_duplicate = hashaddress.is_duplicate
-        assert hashaddress_is_duplicate is False
+        object_metadata = store.put_object(pid, path)
+        object_metadata_is_duplicate = object_metadata.is_duplicate
+        assert object_metadata_is_duplicate is False
 
 
 def test_put_object_hex_digests(pids, store):
@@ -252,13 +237,13 @@ def test_put_object_hex_digests(pids, store):
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_hex_digests = hashaddress.hex_digests
-        assert hashaddress_hex_digests.get("md5") == pids[pid]["md5"]
-        assert hashaddress_hex_digests.get("sha1") == pids[pid]["sha1"]
-        assert hashaddress_hex_digests.get("sha256") == pids[pid]["sha256"]
-        assert hashaddress_hex_digests.get("sha384") == pids[pid]["sha384"]
-        assert hashaddress_hex_digests.get("sha512") == pids[pid]["sha512"]
+        object_metadata = store.put_object(pid, path)
+        object_metadata_hex_digests = object_metadata.hex_digests
+        assert object_metadata_hex_digests.get("md5") == pids[pid]["md5"]
+        assert object_metadata_hex_digests.get("sha1") == pids[pid]["sha1"]
+        assert object_metadata_hex_digests.get("sha256") == pids[pid]["sha256"]
+        assert object_metadata_hex_digests.get("sha384") == pids[pid]["sha384"]
+        assert object_metadata_hex_digests.get("sha512") == pids[pid]["sha512"]
 
 
 def test_put_object_additional_algorithm(pids, store):
@@ -267,8 +252,8 @@ def test_put_object_additional_algorithm(pids, store):
     for pid in pids.keys():
         algo = "sha224"
         path = test_dir + pid.replace("/", "_")
-        hash_address = store.put_object(pid, path, additional_algorithm=algo)
-        hex_digests = hash_address.hex_digests
+        object_metadata = store.put_object(pid, path, additional_algorithm=algo)
+        hex_digests = object_metadata.hex_digests
         sha224_hash = hex_digests.get(algo)
         assert sha224_hash == pids[pid][algo]
 
@@ -309,11 +294,27 @@ def test_move_and_get_checksums_id(pids, store):
             _,
             _,
             _,
-            _,
         ) = store._move_and_get_checksums(pid, input_stream)
         input_stream.close()
         object_cid = store.get_sha256_hex_digest(pid)
         assert move_id == object_cid
+
+
+def test_move_and_get_checksums_file_size(pids, store):
+    """Test move returns correct file size."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        input_stream = io.open(path, "rb")
+        # pylint: disable=W0212
+        (
+            _,
+            tmp_file_size,
+            _,
+            _,
+        ) = store._move_and_get_checksums(pid, input_stream)
+        input_stream.close()
+        assert tmp_file_size == pids[pid]["file_size_bytes"]
 
 
 def test_move_and_get_checksums_hex_digests(pids, store):
@@ -327,7 +328,6 @@ def test_move_and_get_checksums_hex_digests(pids, store):
             _,
             _,
             _,
-            _,
             hex_digests,
         ) = store._move_and_get_checksums(pid, input_stream)
         input_stream.close()
@@ -336,25 +336,6 @@ def test_move_and_get_checksums_hex_digests(pids, store):
         assert hex_digests.get("sha256") == pids[pid]["sha256"]
         assert hex_digests.get("sha384") == pids[pid]["sha384"]
         assert hex_digests.get("sha512") == pids[pid]["sha512"]
-
-
-def test_move_and_get_checksums_abs_path(pids, store):
-    """Test move returns correct absolute path that exists."""
-    test_dir = "tests/testdata/"
-    for pid in pids.keys():
-        path = test_dir + pid.replace("/", "_")
-        input_stream = io.open(path, "rb")
-        # pylint: disable=W0212
-        (
-            _,
-            _,
-            abs_path,
-            _,
-            _,
-        ) = store._move_and_get_checksums(pid, input_stream)
-        input_stream.close()
-        store.get_sha256_hex_digest(pid)
-        assert os.path.isfile(abs_path) is True
 
 
 def test_move_and_get_checksums_duplicates_raises_error(pids, store):
@@ -388,7 +369,9 @@ def test_mktempfile_additional_algo(store):
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )
     # pylint: disable=W0212
-    hex_digests, _ = store._mktempfile(input_stream, additional_algorithm=checksum_algo)
+    hex_digests, _, _ = store._mktempfile(
+        input_stream, additional_algorithm=checksum_algo
+    )
     input_stream.close()
     assert hex_digests.get("sha3_256") == checksum_correct
 
@@ -404,7 +387,9 @@ def test_mktempfile_checksum_algo(store):
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )
     # pylint: disable=W0212
-    hex_digests, _ = store._mktempfile(input_stream, checksum_algorithm=checksum_algo)
+    hex_digests, _, _ = store._mktempfile(
+        input_stream, checksum_algorithm=checksum_algo
+    )
     input_stream.close()
     assert hex_digests.get("sha3_256") == checksum_correct
 
@@ -424,7 +409,7 @@ def test_mktempfile_checksum_and_additional_algo(store):
         "b748069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )
     # pylint: disable=W0212
-    hex_digests, _ = store._mktempfile(
+    hex_digests, _, _ = store._mktempfile(
         input_stream,
         additional_algorithm=additional_algo,
         checksum_algorithm=checksum_algo,
@@ -444,13 +429,25 @@ def test_mktempfile_checksum_and_additional_algo_duplicate(store):
     checksum_algo = "sha224"
     checksum_correct = "9b3a96f434f3c894359193a63437ef86fbd5a1a1a6cc37f1d5013ac1"
     # pylint: disable=W0212
-    hex_digests, _ = store._mktempfile(
+    hex_digests, _, _ = store._mktempfile(
         input_stream,
         additional_algorithm=additional_algo,
         checksum_algorithm=checksum_algo,
     )
     input_stream.close()
     assert hex_digests.get("sha224") == checksum_correct
+
+
+def test_mktempfile_file_size(pids, store):
+    """Test _mktempfile returns correct file size."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        input_stream = io.open(path, "rb")
+        # pylint: disable=W0212
+        _, _, tmp_file_size = store._mktempfile(input_stream)
+        input_stream.close()
+        assert tmp_file_size == pids[pid]["file_size_bytes"]
 
 
 def test_mktempfile_hex_digests(pids, store):
@@ -460,7 +457,7 @@ def test_mktempfile_hex_digests(pids, store):
         path = test_dir + pid.replace("/", "_")
         input_stream = io.open(path, "rb")
         # pylint: disable=W0212
-        hex_digests, _ = store._mktempfile(input_stream)
+        hex_digests, _, _ = store._mktempfile(input_stream)
         input_stream.close()
         assert hex_digests.get("md5") == pids[pid]["md5"]
         assert hex_digests.get("sha1") == pids[pid]["sha1"]
@@ -476,7 +473,7 @@ def test_mktempfile_tmpfile_object(pids, store):
         path = test_dir + pid.replace("/", "_")
         input_stream = io.open(path, "rb")
         # pylint: disable=W0212
-        _, tmp_file_name = store._mktempfile(input_stream)
+        _, tmp_file_name, _ = store._mktempfile(input_stream)
         input_stream.close()
         assert os.path.isfile(tmp_file_name) is True
 
@@ -490,10 +487,10 @@ def test_mktempfile_with_unsupported_algorithm(pids, store):
         algo = "md2"
         with pytest.raises(ValueError):
             # pylint: disable=W0212
-            _, _ = store._mktempfile(input_stream, additional_algorithm=algo)
+            _, _, _ = store._mktempfile(input_stream, additional_algorithm=algo)
         with pytest.raises(ValueError):
             # pylint: disable=W0212
-            _, _ = store._mktempfile(input_stream, checksum_algorithm=algo)
+            _, _, _ = store._mktempfile(input_stream, checksum_algorithm=algo)
         input_stream.close()
 
 
@@ -588,26 +585,14 @@ def test_get_store_path_metadata(store):
     assert path_metadata_string.endswith("/metacat/metadata")
 
 
-def test_exists_with_absolute_path(pids, store):
+def test_exists_with_object_metadata_id(pids, store):
     """Test exists method with an absolute file path."""
     test_dir = "tests/testdata/"
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_abspath = hashaddress.abspath
-        assert store.exists(entity, hashaddress_abspath)
-
-
-def test_exists_with_relative_path(pids, store):
-    """Test exists method with an absolute file path."""
-    test_dir = "tests/testdata/"
-    entity = "objects"
-    for pid in pids.keys():
-        path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_relpath = hashaddress.relpath
-        assert store.exists(entity, hashaddress_relpath)
+        object_metadata = store.put_object(pid, path)
+        assert store.exists(entity, object_metadata.id)
 
 
 def test_exists_with_sharded_path(pids, store):
@@ -616,10 +601,10 @@ def test_exists_with_sharded_path(pids, store):
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_shard = store.shard(hashaddress.id)
-        hashaddress_shard_path = "/".join(hashaddress_shard)
-        assert store.exists(entity, hashaddress_shard_path)
+        object_metadata = store.put_object(pid, path)
+        object_metadata_shard = store.shard(object_metadata.id)
+        object_metadata_shard_path = "/".join(object_metadata_shard)
+        assert store.exists(entity, object_metadata_shard_path)
 
 
 def test_exists_with_nonexistent_file(store):
@@ -649,34 +634,22 @@ def test_open_objects(pids, store):
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hash_address = store.put_object(pid, path)
-        hashaddress_id = hash_address.id
-        io_buffer = store.open(entity, hashaddress_id)
+        object_metadata = store.put_object(pid, path)
+        object_metadata_id = object_metadata.id
+        io_buffer = store.open(entity, object_metadata_id)
         assert isinstance(io_buffer, io.BufferedReader)
         io_buffer.close()
 
 
-def test_delete_by_id(pids, store):
-    """Check objects are deleted after calling delete with id."""
+def test_delete_by_object_metadata_id(pids, store):
+    """Check objects are deleted after calling delete with hash addres id"""
     test_dir = "tests/testdata/"
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hash_address = store.put_object(pid, path)
-        hashaddress_id = hash_address.id
-        store.delete(entity, hashaddress_id)
-    assert store.count(entity) == 0
-
-
-def test_delete_by_path(pids, store):
-    """Check objects are deleted after calling delete with path."""
-    test_dir = "tests/testdata/"
-    entity = "objects"
-    for pid in pids.keys():
-        path = test_dir + pid.replace("/", "_")
-        hash_address = store.put_object(pid, path)
-        hashaddress_relpath = hash_address.relpath
-        store.delete(entity, hashaddress_relpath)
+        object_metadata = store.put_object(pid, path)
+        object_metadata_id = object_metadata.id
+        store.delete(entity, object_metadata_id)
     assert store.count(entity) == 0
 
 
@@ -723,10 +696,11 @@ def test_remove_empty_does_not_remove_nonempty_folders(pids, store):
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hash_address = store.put_object(pid, path)
-        hashaddress_relpath = hash_address.relpath
+        object_metadata = store.put_object(pid, path)
+        object_metadata_shard = store.shard(object_metadata.id)
+        object_metadata_shard_path = "/".join(object_metadata_shard)
         # Get parent directory of the relative path
-        parent_dir = os.path.dirname(hashaddress_relpath)
+        parent_dir = os.path.dirname(object_metadata_shard_path)
         # Attempt to remove the parent directory
         store.remove_empty(parent_dir)
         abs_parent_dir = store.objects + "/" + parent_dir
@@ -779,40 +753,52 @@ def test_get_real_path_file_does_not_exist(store):
     assert real_path_exists is None
 
 
-def test_get_real_path_absolute_path(store, pids):
-    """Test get_real_path returns path (is truthy) when absolute path exists."""
+def test_get_real_path_with_object_id(store, pids):
+    """Test get_real_path returns absolute path given an object id"""
     test_dir = "tests/testdata/"
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_abspath = hashaddress.abspath
-        abs_path = store.get_real_path(entity, hashaddress_abspath)
-        assert abs_path
+        object_metadata = store.put_object(pid, path)
+        obj_abs_path = store.get_real_path(entity, object_metadata.id)
+        assert os.path.exists(obj_abs_path)
 
 
-def test_get_real_path_relative_path(store, pids):
-    """Test get_real_path returns path (is truthy) when rel path exists."""
+def test_get_real_path_with_object_id_sharded(pids, store):
+    """Test exists method with a sharded path (relative path)"""
     test_dir = "tests/testdata/"
     entity = "objects"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_relpath = hashaddress.relpath
-        rel_path = store.get_real_path(entity, hashaddress_relpath)
-        assert rel_path
+        object_metadata = store.put_object(pid, path)
+        object_metadata_shard = store.shard(object_metadata.id)
+        object_metadata_shard_path = "/".join(object_metadata_shard)
+        obj_abs_path = store.get_real_path(entity, object_metadata_shard_path)
+        assert os.path.exists(obj_abs_path)
 
 
-def test_get_real_path_hex_digest_path(store, pids):
-    """Test get_real_path returns path (is truthy) when rel path exists."""
+def test_get_real_path_with_metadata_id(store, pids):
+    """Test get_real_path returns absolute path given a metadata id"""
+    entity = "metadata"
     test_dir = "tests/testdata/"
-    entity = "objects"
+    format_id = "http://ns.dataone.org/service/types/v2.0"
+    for pid in pids.keys():
+        filename = pid.replace("/", "_") + ".xml"
+        syspath = Path(test_dir) / filename
+        metadata_cid = store.store_metadata(pid, syspath, format_id)
+        metadata_abs_path = store.get_real_path(entity, metadata_cid)
+        assert os.path.exists(metadata_abs_path)
+
+
+def test_get_real_path_with_bad_entity(store, pids):
+    """Test get_real_path returns absolute path given an object id"""
+    test_dir = "tests/testdata/"
+    entity = "bad_entity"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
-        hashaddress = store.put_object(pid, path)
-        hashaddress_id = hashaddress.id
-        hex_digest = store.get_real_path(entity, hashaddress_id)
-        assert hex_digest
+        object_metadata = store.put_object(pid, path)
+        with pytest.raises(ValueError):
+            store.get_real_path(entity, object_metadata.id)
 
 
 def test_build_abs_path(store, pids):

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -358,6 +358,26 @@ def test_move_and_get_checksums_duplicates_raises_error(pids, store):
     assert store.count(entity) == 3
 
 
+def test_move_and_get_checksums_file_size_raises_error(pids, store):
+    """Test move and get checksum raises error with incorrect file size"""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        with pytest.raises(ValueError):
+            path = test_dir + pid.replace("/", "_")
+            input_stream = io.open(path, "rb")
+            incorrect_file_size = 1000
+            # pylint: disable=W0212
+            (
+                _,
+                _,
+                _,
+                _,
+            ) = store._move_and_get_checksums(
+                pid, input_stream, file_size_to_validate=incorrect_file_size
+            )
+            input_stream.close()
+
+
 def test_mktempfile_additional_algo(store):
     """Test _mktempfile returns correct hex digests for additional algorithm."""
     test_dir = "tests/testdata/"

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -378,6 +378,49 @@ def test_store_object_duplicate_raises_error(store):
     assert store.exists(entity, object_cid)
 
 
+def test_store_object_with_obj_file_size(store, pids):
+    """Test store object with correct file sizes."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        obj_file_size = pids[pid]["file_size_bytes"]
+        path = test_dir + pid.replace("/", "_")
+        object_metadata = store.store_object(
+            pid, path, expected_object_size=obj_file_size
+        )
+        object_size = object_metadata.obj_size
+        assert object_size == obj_file_size
+
+
+def test_store_object_with_obj_file_size_incorrect(store, pids):
+    """Test store object throws exception with incorrect file size."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        obj_file_size = 1234
+        path = test_dir + pid.replace("/", "_")
+        with pytest.raises(ValueError):
+            store.store_object(pid, path, expected_object_size=obj_file_size)
+
+
+def test_store_object_with_obj_file_size_non_integer(store, pids):
+    """Test store object throws exception with a non integer value as the file size."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        obj_file_size = "Bob"
+        path = test_dir + pid.replace("/", "_")
+        with pytest.raises(TypeError):
+            store.store_object(pid, path, expected_object_size=obj_file_size)
+
+
+def test_store_object_with_obj_file_size_zero(store, pids):
+    """Test store object throws exception with a non integer value as the file size."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        obj_file_size = 0
+        path = test_dir + pid.replace("/", "_")
+        with pytest.raises(ValueError):
+            store.store_object(pid, path, expected_object_size=obj_file_size)
+
+
 def test_store_object_duplicates_threads(store):
     """Test store object thread lock."""
     test_dir = "tests/testdata/"

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -412,7 +412,7 @@ def test_store_object_with_obj_file_size_non_integer(store, pids):
 
 
 def test_store_object_with_obj_file_size_zero(store, pids):
-    """Test store object throws exception with a non integer value as the file size."""
+    """Test store object throws exception with zero as the file size."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         obj_file_size = 0

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -1,7 +1,7 @@
 """Test module for HashStore Module"""
 import os
 import pytest
-from hashstore.hashstore import HashAddress, HashStoreFactory
+from hashstore.hashstore import ObjectMetadata, HashStoreFactory
 from hashstore.filehashstore import FileHashStore
 
 
@@ -87,7 +87,9 @@ def test_hashaddress():
         "sha256": "sha256value",
         "sha512": "sha512value",
     }
-    hash_address = HashAddress(ab_id, rel_path, abs_path, is_duplicate, hex_digest_dict)
+    hash_address = ObjectMetadata(
+        ab_id, rel_path, abs_path, is_duplicate, hex_digest_dict
+    )
     assert hash_address.id == ab_id
     assert hash_address.relpath == rel_path
     assert hash_address.abspath == abs_path

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -77,9 +77,8 @@ def test_factory_get_hashstore_filehashstore_incorrect_algorithm_format(factory)
 def test_hashaddress():
     """Test class returns correct values via dot notation."""
     ab_id = "hashstoretest"
-    rel_path = "rel/path/to/object"
-    abs_path = "abs/path/to/object"
     is_duplicate = "false"
+    obj_size = 1234
     hex_digest_dict = {
         "md5": "md5value",
         "sha1": "sha1value",
@@ -87,15 +86,12 @@ def test_hashaddress():
         "sha256": "sha256value",
         "sha512": "sha512value",
     }
-    hash_address = ObjectMetadata(
-        ab_id, rel_path, abs_path, is_duplicate, hex_digest_dict
-    )
-    assert hash_address.id == ab_id
-    assert hash_address.relpath == rel_path
-    assert hash_address.abspath == abs_path
-    assert hash_address.is_duplicate == is_duplicate
-    assert hash_address.hex_digests.get("md5") == hex_digest_dict["md5"]
-    assert hash_address.hex_digests.get("sha1") == hex_digest_dict["sha1"]
-    assert hash_address.hex_digests.get("sha224") == hex_digest_dict["sha224"]
-    assert hash_address.hex_digests.get("sha256") == hex_digest_dict["sha256"]
-    assert hash_address.hex_digests.get("sha512") == hex_digest_dict["sha512"]
+    object_metadata = ObjectMetadata(ab_id, obj_size, is_duplicate, hex_digest_dict)
+    assert object_metadata.id == ab_id
+    assert object_metadata.obj_size == obj_size
+    assert object_metadata.is_duplicate == is_duplicate
+    assert object_metadata.hex_digests.get("md5") == hex_digest_dict["md5"]
+    assert object_metadata.hex_digests.get("sha1") == hex_digest_dict["sha1"]
+    assert object_metadata.hex_digests.get("sha224") == hex_digest_dict["sha224"]
+    assert object_metadata.hex_digests.get("sha256") == hex_digest_dict["sha256"]
+    assert object_metadata.hex_digests.get("sha512") == hex_digest_dict["sha512"]

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -37,7 +37,7 @@ def test_factory_get_hashstore_unsupported_class(factory):
 def test_factory_get_hashstore_unsupported_module(factory):
     """Check that ModuleNotFoundError is raised when provided with unsupported module."""
     with pytest.raises(ModuleNotFoundError):
-        module_name = "hashstore.s3filestore.s3filestore"
+        module_name = "hashstore.s3filestore"
         class_name = "FileHashStore"
         factory.get_hashstore(module_name, class_name)
 
@@ -51,7 +51,7 @@ def test_factory_get_hashstore_filehashstore_unsupported_algorithm(factory):
         "store_path": os.getcwd() + "/metacat/test",
         "store_depth": 3,
         "store_width": 2,
-        "store_algorithm": "md2",
+        "store_algorithm": "MD2",
         "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
     with pytest.raises(ValueError):


### PR DESCRIPTION
Summary of Changs:
- Rename `HashAddress` to `ObjectMetadata`
- Remove relative path and absolute path attributes from `ObjectMetadata` and added new attribute `obj_size`
- Update `HashStore` interface method `store_object()` doc strings for new signature value `expected_object_size`
- Refactor `store_object()` and related methods to accommodate new value, add logic to validate the `expected_object_size` against the file size calculated, and add/update pytests.