### PR TITLE
Feature-90: `store_object` Exceptions & Logging

### DIFF
--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -1701,10 +1701,10 @@ class FileHashStore(HashStore):
                         exception_string
                         + f" Tmp file deleted and file not stored for pid: {pid}"
                     )
-                    logging.error(exception_string_for_pid)
+                    logging.warning(exception_string_for_pid)
                     raise ValueError(exception_string_for_pid)
                 else:
-                    logging.error(exception_string)
+                    logging.warning(exception_string)
                     raise ValueError(exception_string)
         if checksum_algorithm is not None and checksum is not None:
             if checksum_algorithm not in hex_digests:
@@ -1712,7 +1712,7 @@ class FileHashStore(HashStore):
                     "FileHashStore - _verify_object_information: checksum_algorithm"
                     + f" ({checksum_algorithm}) cannot be found in the hex digests dictionary."
                 )
-                logging.error(exception_string)
+                logging.warning(exception_string)
                 raise KeyError(exception_string)
             else:
                 hex_digest_stored = hex_digests[checksum_algorithm]
@@ -1729,14 +1729,14 @@ class FileHashStore(HashStore):
                         exception_string_for_pid = (
                             exception_string + f" Tmp file ({tmp_file_name}) deleted."
                         )
-                        logging.error(exception_string_for_pid)
+                        logging.warning(exception_string_for_pid)
                         raise ValueError(exception_string_for_pid)
                     else:
                         # Delete the object
                         cid = hex_digests[self.algorithm]
                         cid_abs_path = self._resolve_path("cid", cid)
                         self._delete(entity, cid_abs_path)
-                        logging.error(exception_string)
+                        logging.warning(exception_string)
                         raise ValueError(exception_string)
 
     def _verify_hashstore_references(self, pid, cid, additional_log_string):

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -478,11 +478,10 @@ class FileHashStore(HashStore):
                     pid,
                 )
             except PidObjectMetadataError as ome:
-                # Note, using '.__cause__' allows the original exception msg to be displayed
                 exception_string = (
                     f"FileHashStore - store_object: failed to store object for pid: {pid}."
-                    + " Reference files will not be created or tagged. PidObjectMetadataError:"
-                    + ome.__cause__
+                    + " Reference files will not be created or tagged. PidObjectMetadataError: "
+                    + str(ome)
                 )
                 logging.error(exception_string)
                 raise ome
@@ -490,7 +489,7 @@ class FileHashStore(HashStore):
                 exception_string = (
                     f"FileHashStore - store_object: failed to store object for pid: {pid}."
                     + " Reference files will not be created or tagged. Unexpected error: "
-                    + err.__cause__
+                    + str(err)
                 )
                 logging.error(exception_string)
                 raise err
@@ -1361,9 +1360,9 @@ class FileHashStore(HashStore):
                 exception_string = (
                     f"FileHashStore - _move_and_get_checksums: Object already exists for pid: {pid}"
                     + " , deleting temp file. Reference files will not be created and/or tagged"
-                    + " due to an issue with the supplied pid object metadata."
+                    + f" due to an issue with the supplied pid object metadata. {ve}"
                 )
-                logging.warning(exception_string)
+                logging.debug(exception_string)
                 raise PidObjectMetadataError(exception_string) from ve
             finally:
                 # Delete the temporary file, it already exists so it is redundant

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -477,7 +477,7 @@ class FileHashStore(HashStore):
                     "FileHashStore - store_object: Successfully stored object for pid: %s",
                     pid,
                 )
-            except ObjectMetadataError as ome:
+            except PidObjectMetadataError as ome:
                 # Note, using '.__cause__' allows the original exception msg to be displayed
                 exception_string = (
                     f"FileHashStore - store_object: failed to store object for pid: {pid}."

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -481,14 +481,16 @@ class FileHashStore(HashStore):
                 # Note, using '.__cause__' allows the original exception msg to be displayed
                 exception_string = (
                     f"FileHashStore - store_object: failed to store object for pid: {pid}."
-                    + f" Reference files will not be created or tagged. {ome.__cause__}"
+                    + " Reference files will not be created or tagged. PidObjectMetadataError:"
+                    + ome.__cause__
                 )
                 logging.error(exception_string)
                 raise ome
             except Exception as err:
                 exception_string = (
                     f"FileHashStore - store_object: failed to store object for pid: {pid}."
-                    + f" Unexpected error: {err.__cause__}"
+                    + " Reference files will not be created or tagged. Unexpected error: "
+                    + err.__cause__
                 )
                 logging.error(exception_string)
                 raise err

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -11,6 +11,7 @@ import pytest
 
 from hashstore.filehashstore import (
     CidRefsDoesNotExist,
+    PidObjectMetadataError,
     PidNotFoundInCidRefsFile,
     PidRefsDoesNotExist,
     RefsFileExistsButCidObjMissing,
@@ -420,7 +421,7 @@ def test_store_object_duplicate_raises_error_with_bad_validation_data(pids, stor
     # Store first blob
     _object_metadata_one = store.store_object(pid, path)
     # Store second blob
-    with pytest.raises(ValueError):
+    with pytest.raises(PidObjectMetadataError):
         _object_metadata_two = store.store_object(
             pid, path, checksum="nonmatchingchecksum", checksum_algorithm="sha256"
         )


### PR DESCRIPTION
When an object fails to store a series of exceptions are logged which are redundant/repetitive (too much info).

**Summary of Changes:**
- Logging levels have been adjusted for the entire `store_object` process and related methods so that only one exception is thrown with the relevant stack trace/errors.
- Exception messaging has been revised to improve clarity
- New custom exception "PidObjectMetadataError"