### PR TITLE
BugFix-97: `tag_object` cid refs file missing pids

### DIFF
--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -574,8 +574,10 @@ class FileHashStore(HashStore):
         if use_multiprocessing:
             while cid in self.reference_locked_cids_mp:
                 logging.debug(
-                    "FileHashStore - tag_object (mp): (cid) %s is currently locked. Waiting.",
+                    "FileHashStore - tag_object (mp): (cid) %s is currently locked. Waiting"
+                    + " to tag pid: %s",
                     cid,
+                    pid,
                 )
                 time.sleep(self.time_out_sec)
             with self.reference_lock_mp:
@@ -599,13 +601,7 @@ class FileHashStore(HashStore):
                     pid,
                 )
                 self.reference_locked_cids.append(cid)
-        # with self.reference_lock:
-        #     logging.debug(
-        #         "FileHashStore - tag_object: Locking cid: %s to to tag pid: %s.",
-        #         cid,
-        #         pid,
-        #     )
-        #     self.reference_locked_cids.append(cid)
+
         try:
             tmp_root_path = self._get_store_path("refs") / "tmp"
             pid_refs_path = self._resolve_path("pid", pid)
@@ -726,8 +722,8 @@ class FileHashStore(HashStore):
             if use_multiprocessing:
                 with self.reference_lock_mp:
                     logging.debug(
-                        "FileHashStore - tag_object (mp): Removing cid: %s from reference_locked_cids.",
-                        cid,
+                        "FileHashStore - tag_object (mp): Removing cid: %s from"
+                        + " reference_locked_cids.", cid,
                     )
                     self.reference_locked_cids_mp.remove(cid)
             else:
@@ -737,12 +733,6 @@ class FileHashStore(HashStore):
                         cid,
                     )
                     self.reference_locked_cids.remove(cid)
-            # with self.reference_lock:
-            #     logging.debug(
-            #         "FileHashStore - tag_object: Removing cid: %s from reference_locked_cids.",
-            #         cid,
-            #     )
-            #     self.reference_locked_cids.remove(cid)
 
     def find_object(self, pid):
         logging.debug(

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -574,8 +574,8 @@ class FileHashStore(HashStore):
         # Modify reference_locked_cids consecutively
         with self.reference_lock:
             logging.debug(
-                "FileHashStore - tag_object: Adding cid: %s to reference_locked_cids.",
-                cid,
+                "FileHashStore - tag_object: Locking cid: %s to to tag pid: %s.",
+                cid, pid
             )
             self.reference_locked_cids.append(cid)
         try:

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -450,6 +450,7 @@ class FileHashStore(HashStore):
                 additional_algorithm, checksum, checksum_algorithm
             )
 
+            # TODO: Implement multiprocessing lock check like 'tag_object'
             # Wait for the pid to release if it's in use
             while pid in self.object_locked_pids:
                 logging.debug(
@@ -723,7 +724,8 @@ class FileHashStore(HashStore):
                 with self.reference_lock_mp:
                     logging.debug(
                         "FileHashStore - tag_object (mp): Removing cid: %s from"
-                        + " reference_locked_cids.", cid,
+                        + " reference_locked_cids.",
+                        cid,
                     )
                     self.reference_locked_cids_mp.remove(cid)
             else:
@@ -797,6 +799,7 @@ class FileHashStore(HashStore):
         checked_format_id = self._check_arg_format_id(format_id, "store_metadata")
         self._check_arg_data(metadata)
 
+        # TODO: Implement multiprocessing lock check like 'tag_object'
         # Wait for the pid to release if it's in use
         while pid in self.metadata_locked_pids:
             logging.debug(
@@ -903,6 +906,7 @@ class FileHashStore(HashStore):
             # If the refs file still exists, do not delete the object
             if not os.path.exists(cid_refs_abs_path):
                 cid = ab_id
+                # TODO: Implement multiprocessing lock check like 'tag_object'
                 # Synchronize the cid
                 while cid in self.reference_locked_cids:
                     logging.debug(
@@ -1123,6 +1127,7 @@ class FileHashStore(HashStore):
             "FileHashStore - delete_metadata: Request to delete metadata for pid: %s",
             pid,
         )
+        # TODO: Implement multiprocessing lock check like 'tag_object'
         self._check_string(pid, "pid", "delete_metadata")
         checked_format_id = self._check_arg_format_id(format_id, "delete_metadata")
         # Get the metadata directory path for the given pid

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -569,17 +569,6 @@ class FileHashStore(HashStore):
         )
         self._check_string(pid, "pid", "tag_object")
         self._check_string(cid, "cid", "tag_object")
-        # Prepare files and paths
-        tmp_root_path = self._get_store_path("refs") / "tmp"
-        pid_refs_path = self._resolve_path("pid", pid)
-        cid_refs_path = self._resolve_path("cid", cid)
-        # All ref files begin as tmp files and get moved sequentially at once
-        # Get tmp files with the expected cid and pid refs content
-        pid_tmp_file_path = self._write_refs_file(tmp_root_path, cid, "pid")
-        cid_tmp_file_path = self._write_refs_file(tmp_root_path, pid, "cid")
-        # Create paths for pid ref file in '.../refs/pid' and cid ref file in '.../refs/cid'
-        self._create_path(os.path.dirname(pid_refs_path))
-        self._create_path(os.path.dirname(cid_refs_path))
 
         # Modify reference_locked_cids consecutively
         # Wait for the cid to release if it's being tagged
@@ -614,8 +603,19 @@ class FileHashStore(HashStore):
                     pid,
                 )
                 self.reference_locked_cids.append(cid)
-
         try:
+            # Prepare files and paths
+            tmp_root_path = self._get_store_path("refs") / "tmp"
+            pid_refs_path = self._resolve_path("pid", pid)
+            cid_refs_path = self._resolve_path("cid", cid)
+            # All ref files begin as tmp files and get moved sequentially at once
+            # Get tmp files with the expected cid and pid refs content
+            pid_tmp_file_path = self._write_refs_file(tmp_root_path, cid, "pid")
+            cid_tmp_file_path = self._write_refs_file(tmp_root_path, pid, "cid")
+            # Create paths for pid ref file in '.../refs/pid' and cid ref file in '.../refs/cid'
+            self._create_path(os.path.dirname(pid_refs_path))
+            self._create_path(os.path.dirname(cid_refs_path))
+
             if os.path.exists(pid_refs_path) and os.path.exists(cid_refs_path):
                 self._verify_hashstore_references(
                     pid,

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -607,10 +607,10 @@ class FileHashStore(HashStore):
             tmp_root_path = self._get_store_path("refs") / "tmp"
             pid_refs_path = self._resolve_path("pid", pid)
             cid_refs_path = self._resolve_path("cid", cid)
-            pid_ref_abs_path_exists = os.path.exists(pid_refs_path)
-            cid_ref_abs_path_exists = os.path.exists(cid_refs_path)
+            # pid_ref_abs_path_exists = os.path.exists(pid_refs_path)
+            # cid_ref_abs_path_exists = os.path.exists(cid_refs_path)
 
-            if pid_ref_abs_path_exists and cid_ref_abs_path_exists:
+            if os.path.exists(pid_refs_path) and os.path.exists(cid_refs_path):
                 self._verify_hashstore_references(
                     pid,
                     cid,
@@ -619,7 +619,7 @@ class FileHashStore(HashStore):
                     "Refs file already exists, verifying.",
                 )
                 return True
-            elif pid_ref_abs_path_exists and not cid_ref_abs_path_exists:
+            elif os.path.exists(pid_refs_path) and not os.path.exists(cid_refs_path):
                 debug_msg = (
                     f"FileHashStore - tag_object: pid refs file exists ({pid_refs_path})"
                     + f" for pid: {pid}, but cid refs file doesn't at: {cid_refs_path}"
@@ -669,7 +669,7 @@ class FileHashStore(HashStore):
                     # Orphaned pid refs file found, the retrieved cid refs file exists
                     # but doesn't contain the cid. Proceed to overwrite the pid refs file.
                     # There is no return statement, so we move out of this if block.
-            elif not pid_ref_abs_path_exists and cid_ref_abs_path_exists:
+            elif not os.path.exists(pid_refs_path) and os.path.exists(cid_refs_path):
                 debug_msg = (
                     f"FileHashStore - tag_object: pid refs file does not exists for pid {pid}"
                     + f" but cid refs file exists at: {cid_refs_path}  for cid: {cid}"

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -588,7 +588,7 @@ class FileHashStore(HashStore):
                     )
                     self.multiprocessing_condition.wait()
                 # Add cid to tracking array
-                self.reference_locked_cids.append(cid)
+                self.reference_locked_cids_mp.append(cid)
         else:
             with self.thread_condition:
                 while cid in self.reference_locked_cids:

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -479,13 +479,6 @@ class FileHashStore(HashStore):
                     pid,
                 )
                 cid = object_metadata.cid
-                while cid in self.reference_locked_cids:
-                    logging.debug(
-                        "FileHashStore - store_object: Waiting to tag pid (%s) with cid (%s)",
-                        pid,
-                        cid,
-                    )
-                    time.sleep(self.time_out_sec)
                 self.tag_object(pid, cid)
                 logging.info(
                     "FileHashStore - store_object: Successfully stored object for pid: %s",

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -662,7 +662,7 @@ class FileHashStore(HashStore):
                             + f" and cid reference files for pid: {pid} with cid: {cid}."
                         )
                         logging.error(error_msg)
-                        raise PidRefsExistsError(error_msg)
+                        raise PidAlreadyExistsError(error_msg)
                     else:
                         debug_msg = (
                             f"FileHashStore - tag_object: Orphan pid refs file found for {pid}."
@@ -2427,7 +2427,7 @@ class Stream(object):
             self._obj.seek(self._pos)
 
 
-class PidRefsExistsError(Exception):
+class PidAlreadyExistsError(Exception):
     """Custom exception thrown when a client calls 'tag_object' and the pid
     that is being tagged is already accounted for (has a pid refs file and
     is found in the cid refs file)."""

--- a/src/hashstore/hashstoreclient.py
+++ b/src/hashstore/hashstoreclient.py
@@ -285,6 +285,15 @@ class HashStoreClient:
         )
         logging.info(info_msg)
 
+        # Test Begin
+        # Set multiprocessing to true
+        os.environ["USE_MULTIPROCESSING"] = "True"
+        use_multiprocessing = os.getenv("USE_MULTIPROCESSING", "False") == "True"
+        logging.info(
+            "HashStoreClient - use_multiprocessing (bool): %s", use_multiprocessing
+        )
+        # Test End
+
         # Get list of objects to store from metacat db
         if obj_type == self.OBJ_TYPE:
             checked_obj_list = self.metacatdb.refine_list_for_objects(

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -1,6 +1,7 @@
 """Test module for FileHashStore HashStore interface methods."""
 
 import io
+import multiprocessing
 import os
 from pathlib import Path
 from threading import Thread
@@ -497,6 +498,12 @@ def test_store_object_duplicates_threads(pids, store):
     assert store._exists(entity, pids[pid][store.algorithm])
 
 
+# Note:
+# Multiprocessing has been tested through the HashStore client using
+# metacat db data from 'test.arcticdata.io'. When time-permitting,
+# implement a multiprocessing test
+
+
 def test_store_object_threads_multiple_pids_one_cid(pids, store):
     """Test store object thread lock."""
     entity = "objects"
@@ -527,7 +534,7 @@ def test_store_object_threads_multiple_pids_one_cid(pids, store):
     thread4.join()
     thread5.join()
     thread6.join()
-    # One thread will succeed, file count must still be 1
+    # All threads will succeed, file count must still be 1
     assert store._count(entity) == 1
     assert store._exists(entity, pids["jtao.1700.1"][store.algorithm])
 

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -1,7 +1,6 @@
 """Test module for FileHashStore HashStore interface methods."""
 
 import io
-import multiprocessing
 import os
 from pathlib import Path
 from threading import Thread

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -360,7 +360,7 @@ def test_verify_hashstore_references_pid_refs_file_missing(pids, store):
     for pid in pids.keys():
         cid = pids[pid]["sha256"]
         with pytest.raises(FileNotFoundError):
-            store._verify_hashstore_references(pid, cid, "create")
+            store._verify_hashstore_references(pid, cid)
 
 
 def test_verify_hashstore_references_pid_refs_incorrect_cid(pids, store):
@@ -371,17 +371,19 @@ def test_verify_hashstore_references_pid_refs_incorrect_cid(pids, store):
         tmp_root_path = store._get_store_path("refs") / "tmp"
         tmp_cid_refs_file = store._write_refs_file(tmp_root_path, pid, "cid")
         cid_ref_abs_path = store._resolve_path("cid", cid)
+        print(cid_ref_abs_path)
         store._create_path(os.path.dirname(cid_ref_abs_path))
         shutil.move(tmp_cid_refs_file, cid_ref_abs_path)
         # Write the pid refs file and move it where it needs to be with a bad cid
         pid_ref_abs_path = store._resolve_path("pid", pid)
+        print(pid_ref_abs_path)
         store._create_path(os.path.dirname(pid_ref_abs_path))
         tmp_root_path = store._get_store_path("refs") / "tmp"
         tmp_pid_refs_file = store._write_refs_file(tmp_root_path, "bad_cid", "pid")
         shutil.move(tmp_pid_refs_file, pid_ref_abs_path)
 
         with pytest.raises(ValueError):
-            store._verify_hashstore_references(pid, cid, "create")
+            store._verify_hashstore_references(pid, cid)
 
 
 def test_verify_hashstore_references_cid_refs_file_missing(pids, store):
@@ -395,7 +397,7 @@ def test_verify_hashstore_references_cid_refs_file_missing(pids, store):
         shutil.move(tmp_pid_refs_file, pid_ref_abs_path)
 
         with pytest.raises(FileNotFoundError):
-            store._verify_hashstore_references(pid, cid, "create")
+            store._verify_hashstore_references(pid, cid)
 
 
 def test_verify_hashstore_references_cid_refs_file_missing_pid(pids, store):
@@ -417,7 +419,7 @@ def test_verify_hashstore_references_cid_refs_file_missing_pid(pids, store):
         shutil.move(tmp_pid_refs_file, pid_ref_abs_path)
 
         with pytest.raises(ValueError):
-            store._verify_hashstore_references(pid, cid, "create")
+            store._verify_hashstore_references(pid, cid)
 
 
 def test_verify_hashstore_references_cid_refs_file_with_multiple_refs_missing_pid(
@@ -446,4 +448,4 @@ def test_verify_hashstore_references_cid_refs_file_with_multiple_refs_missing_pi
             cid_reference_list.append(f"dou.test.{i}")
 
         with pytest.raises(ValueError):
-            store._verify_hashstore_references(pid, cid, "create")
+            store._verify_hashstore_references(pid, cid)

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import pytest
 
-from hashstore.filehashstore import PidRefsExistsError
+from hashstore.filehashstore import PidAlreadyExistsError
 
 # pylint: disable=W0212
 
@@ -114,7 +114,7 @@ def test_tag_object_pid_refs_found_cid_refs_not_found_different_cid_retrieved(st
     path = test_dir + pid.replace("/", "_")
     _object_metadata = store.store_object(pid, path)
 
-    with pytest.raises(PidRefsExistsError):
+    with pytest.raises(PidAlreadyExistsError):
         store.tag_object(pid, "another_cid_value_that_is_not_found")
 
 

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -4,6 +4,8 @@ import os
 import shutil
 import pytest
 
+from hashstore.filehashstore import PidRefsExistsError
+
 # pylint: disable=W0212
 
 
@@ -112,7 +114,7 @@ def test_tag_object_pid_refs_found_cid_refs_not_found_different_cid_retrieved(st
     path = test_dir + pid.replace("/", "_")
     _object_metadata = store.store_object(pid, path)
 
-    with pytest.raises(FileExistsError):
+    with pytest.raises(PidRefsExistsError):
         store.tag_object(pid, "another_cid_value_that_is_not_found")
 
 


### PR DESCRIPTION
Summary of Changes:
- Revised tagging synchronization process to use threading/multiprocessing library conditions in `tag_object` & new pytest to check fixes
- Add new custom exception `PidAlreadyExistsError` for improved clarity