### PR TITLE
BugFix-101: `cid refs file` does not get cleaned up

### DIFF
--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -604,10 +604,6 @@ class FileHashStore(HashStore):
             tmp_root_path = self._get_store_path("refs") / "tmp"
             pid_refs_path = self._resolve_path("pid", pid)
             cid_refs_path = self._resolve_path("cid", cid)
-            # All ref files begin as tmp files and get moved sequentially at once
-            # Get tmp files with the expected cid and pid refs content
-            pid_tmp_file_path = self._write_refs_file(tmp_root_path, cid, "pid")
-            cid_tmp_file_path = self._write_refs_file(tmp_root_path, pid, "cid")
             # Create paths for pid ref file in '.../refs/pid' and cid ref file in '.../refs/cid'
             self._create_path(os.path.dirname(pid_refs_path))
             self._create_path(os.path.dirname(cid_refs_path))
@@ -635,6 +631,7 @@ class FileHashStore(HashStore):
 
                 if self._is_string_in_refs_file(cid, pid_refs_path):
                     # The pid correctly references the given cid, but the cid refs file is missing
+                    cid_tmp_file_path = self._write_refs_file(tmp_root_path, pid, "cid")
                     shutil.move(cid_tmp_file_path, cid_refs_path)
                     self._verify_hashstore_references(
                         pid,
@@ -676,6 +673,7 @@ class FileHashStore(HashStore):
                 )
                 logging.debug(debug_msg)
                 # Move the pid refs file
+                pid_tmp_file_path = self._write_refs_file(tmp_root_path, cid, "pid")
                 shutil.move(pid_tmp_file_path, pid_refs_path)
                 # Update cid ref files as it already exists
                 if not self._is_string_in_refs_file(pid, cid_refs_path):
@@ -695,6 +693,8 @@ class FileHashStore(HashStore):
                 return True
 
             # Move both files after checking the existing status of refs files
+            pid_tmp_file_path = self._write_refs_file(tmp_root_path, cid, "pid")
+            cid_tmp_file_path = self._write_refs_file(tmp_root_path, pid, "cid")
             shutil.move(pid_tmp_file_path, pid_refs_path)
             shutil.move(cid_tmp_file_path, cid_refs_path)
             log_msg = "Reference files have been moved to their permanent location. Verifying refs."

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -504,7 +504,7 @@ def test_store_object_duplicates_threads(pids, store):
 
 
 def test_store_object_threads_multiple_pids_one_cid_content(pids, store):
-    """Test store object thread lock."""
+    """Test store object thread lock and refs files content"""
     entity = "objects"
     test_dir = "tests/testdata/"
     path = test_dir + "jtao.1700.1"
@@ -551,7 +551,7 @@ def test_store_object_threads_multiple_pids_one_cid_content(pids, store):
 
 
 def test_store_object_threads_multiple_pids_one_cid_files(store):
-    """Test store object with threads produces the right amount of files"""
+    """Test store object with threads produces the expected amount of files"""
     test_dir = "tests/testdata/"
     path = test_dir + "jtao.1700.1"
     pid_list = ["jtao.1700.1"]


### PR DESCRIPTION
Summary of Changes:
- Revised 'tag_object' to create the necessary refs files (`pid` or `cid`) when they are needed & added new pytest