### PR TITLE
Feature-109: `verify_object` Update

### DIFF
--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -14,6 +14,20 @@ from tempfile import NamedTemporaryFile
 import fcntl
 import yaml
 from hashstore import HashStore, ObjectMetadata
+from hashstore.filehashstore_exceptions import (
+    CidRefsContentError,
+    CidRefsDoesNotExist,
+    CidRefsFileNotFound,
+    NonMatchingChecksum,
+    NonMatchingObjSize,
+    PidAlreadyExistsError,
+    PidNotFoundInCidRefsFile,
+    PidRefsContentError,
+    PidRefsDoesNotExist,
+    PidRefsFileNotFound,
+    RefsFileExistsButCidObjMissing,
+    UnsupportedAlgorithm,
+)
 
 
 class FileHashStore(HashStore):
@@ -2570,110 +2584,3 @@ class Stream(object):
             self._obj.close()
         else:
             self._obj.seek(self._pos)
-
-
-class PidRefsFileNotFound(Exception):
-    """Custom exception thrown when verifying reference files and a pid refs
-    file is not found."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class CidRefsFileNotFound(Exception):
-    """Custom exception thrown when verifying reference files and a cid refs
-    file is not found."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class PidRefsContentError(Exception):
-    """Custom exception thrown when verifying reference files and a pid refs
-    file does not contain the cid that it is expected."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class CidRefsContentError(Exception):
-    """Custom exception thrown when verifying reference files and a cid refs
-    file does not have a pid that is expected to be found."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class PidAlreadyExistsError(Exception):
-    """Custom exception thrown when a client calls 'tag_object' and the pid
-    that is being tagged is already accounted for (has a pid refs file and
-    is found in the cid refs file)."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class PidRefsDoesNotExist(Exception):
-    """Custom exception thrown when a pid refs file does not exist."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class CidRefsDoesNotExist(Exception):
-    """Custom exception thrown when a cid refs file does not exist."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class RefsFileExistsButCidObjMissing(Exception):
-    """Custom exception thrown when pid and cid refs file exists, but the
-    cid object does not."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class PidNotFoundInCidRefsFile(Exception):
-    """Custom exception thrown when pid reference file exists with a cid, but
-    the respective cid reference file does not contain the pid."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class NonMatchingObjSize(Exception):
-    """Custom exception thrown when verifying an object and the expected file size
-    does not match what has been calculated."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class NonMatchingChecksum(Exception):
-    """Custom exception thrown when verifying an object and the expected checksum
-    does not match what has been calculated."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class UnsupportedAlgorithm(Exception):
-    """Custom exception thrown when a given algorithm is not supported in HashStore for
-    calculating hashes/checksums, as the default store algo and/or other operations."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -2012,7 +2012,7 @@ class FileHashStore(HashStore):
                 + f" . Additional Context: {additional_log_string}"
             )
             logging.error(exception_string)
-            raise FileNotFoundError(exception_string)
+            raise PidRefsFileNotFound(exception_string)
         if not os.path.exists(cid_refs_path):
             exception_string = (
                 "FileHashStore - _verify_hashstore_references: Cid refs file missing: "
@@ -2020,7 +2020,7 @@ class FileHashStore(HashStore):
                 + f" . Additional Context: {additional_log_string}"
             )
             logging.error(exception_string)
-            raise FileNotFoundError(exception_string)
+            raise CidRefsFileNotFound(exception_string)
         # Check the content of the reference files
         # Start with the cid
         with open(pid_refs_path, "r", encoding="utf8") as f:
@@ -2032,7 +2032,7 @@ class FileHashStore(HashStore):
                 + f" Additional Context: {additional_log_string}"
             )
             logging.error(exception_string)
-            raise ValueError(exception_string)
+            raise PidRefsContentError(exception_string)
         # Then the pid
         pid_found = self._is_string_in_refs_file(pid, cid_refs_path)
         if not pid_found:
@@ -2042,7 +2042,7 @@ class FileHashStore(HashStore):
                 + f" Additional Context:  {additional_log_string}"
             )
             logging.error(exception_string)
-            raise ValueError(exception_string)
+            raise CidRefsContentError(exception_string)
 
     @staticmethod
     def _check_arg_data(data):
@@ -2570,6 +2570,42 @@ class Stream(object):
             self._obj.close()
         else:
             self._obj.seek(self._pos)
+
+
+class PidRefsFileNotFound(Exception):
+    """Custom exception thrown when verifying reference files and a pid refs
+    file is not found."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class CidRefsFileNotFound(Exception):
+    """Custom exception thrown when verifying reference files and a cid refs
+    file is not found."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class PidRefsContentError(Exception):
+    """Custom exception thrown when verifying reference files and a pid refs
+    file does not contain the cid that it is expected."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class CidRefsContentError(Exception):
+    """Custom exception thrown when verifying reference files and a cid refs
+    file does not have a pid that is expected to be found."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
 
 
 class PidAlreadyExistsError(Exception):

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -1928,6 +1928,9 @@ class FileHashStore(HashStore):
                     raise NonMatchingObjSize(exception_string)
         if checksum_algorithm is not None and checksum is not None:
             if checksum_algorithm not in hex_digests:
+                # Check to see if it is a supported algorithm
+                self._clean_algorithm(checksum_algorithm)
+                # TODO: If so, calculate the checksum and compare it
                 exception_string = (
                     "FileHashStore - _verify_object_information: checksum_algorithm"
                     + f" ({checksum_algorithm}) cannot be found in the hex digests dictionary."
@@ -2176,7 +2179,7 @@ class FileHashStore(HashStore):
                 + cleaned_string
             )
             logging.error(exception_string)
-            raise ValueError(exception_string)
+            raise UnsupportedAlgorithm(exception_string)
         return cleaned_string
 
     def _computehash(self, stream, algorithm=None):
@@ -2610,6 +2613,15 @@ class NonMatchingObjSize(Exception):
 class NonMatchingChecksum(Exception):
     """Custom exception thrown when verifying an object and the expected checksum
     does not match what has been calculated."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class UnsupportedAlgorithm(Exception):
+    """Custom exception thrown when a given algorithm is not supported in HashStore for
+    calculating hashes/checksums, as the default store algo and/or other operations."""
 
     def __init__(self, message, errors=None):
         super().__init__(message)

--- a/src/hashstore/filehashstore_exceptions.py
+++ b/src/hashstore/filehashstore_exceptions.py
@@ -1,0 +1,105 @@
+class PidRefsFileNotFound(Exception):
+    """Custom exception thrown when verifying reference files and a pid refs
+    file is not found."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class CidRefsFileNotFound(Exception):
+    """Custom exception thrown when verifying reference files and a cid refs
+    file is not found."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class PidRefsContentError(Exception):
+    """Custom exception thrown when verifying reference files and a pid refs
+    file does not contain the cid that it is expected."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class CidRefsContentError(Exception):
+    """Custom exception thrown when verifying reference files and a cid refs
+    file does not have a pid that is expected to be found."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class PidAlreadyExistsError(Exception):
+    """Custom exception thrown when a client calls 'tag_object' and the pid
+    that is being tagged is already accounted for (has a pid refs file and
+    is found in the cid refs file)."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class PidRefsDoesNotExist(Exception):
+    """Custom exception thrown when a pid refs file does not exist."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class CidRefsDoesNotExist(Exception):
+    """Custom exception thrown when a cid refs file does not exist."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class RefsFileExistsButCidObjMissing(Exception):
+    """Custom exception thrown when pid and cid refs file exists, but the
+    cid object does not."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class PidNotFoundInCidRefsFile(Exception):
+    """Custom exception thrown when pid reference file exists with a cid, but
+    the respective cid reference file does not contain the pid."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class NonMatchingObjSize(Exception):
+    """Custom exception thrown when verifying an object and the expected file size
+    does not match what has been calculated."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class NonMatchingChecksum(Exception):
+    """Custom exception thrown when verifying an object and the expected checksum
+    does not match what has been calculated."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class UnsupportedAlgorithm(Exception):
+    """Custom exception thrown when a given algorithm is not supported in HashStore for
+    calculating hashes/checksums, as the default store algo and/or other operations."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors

--- a/src/hashstore/filehashstore_exceptions.py
+++ b/src/hashstore/filehashstore_exceptions.py
@@ -1,6 +1,9 @@
-class PidRefsFileNotFound(Exception):
-    """Custom exception thrown when verifying reference files and a pid refs
-    file is not found."""
+"""FileHashStore custom exception module."""
+
+
+class CidRefsContentError(Exception):
+    """Custom exception thrown when verifying reference files and a cid refs
+    file does not have a pid that is expected to be found."""
 
     def __init__(self, message, errors=None):
         super().__init__(message)
@@ -16,6 +19,14 @@ class CidRefsFileNotFound(Exception):
         self.errors = errors
 
 
+class CidRefsDoesNotExist(Exception):
+    """Custom exception thrown when a cid refs file does not exist."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
 class PidRefsContentError(Exception):
     """Custom exception thrown when verifying reference files and a pid refs
     file does not contain the cid that it is expected."""
@@ -25,9 +36,9 @@ class PidRefsContentError(Exception):
         self.errors = errors
 
 
-class CidRefsContentError(Exception):
-    """Custom exception thrown when verifying reference files and a cid refs
-    file does not have a pid that is expected to be found."""
+class PidRefsFileNotFound(Exception):
+    """Custom exception thrown when verifying reference files and a pid refs
+    file is not found."""
 
     def __init__(self, message, errors=None):
         super().__init__(message)
@@ -46,23 +57,6 @@ class PidAlreadyExistsError(Exception):
 
 class PidRefsDoesNotExist(Exception):
     """Custom exception thrown when a pid refs file does not exist."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class CidRefsDoesNotExist(Exception):
-    """Custom exception thrown when a cid refs file does not exist."""
-
-    def __init__(self, message, errors=None):
-        super().__init__(message)
-        self.errors = errors
-
-
-class RefsFileExistsButCidObjMissing(Exception):
-    """Custom exception thrown when pid and cid refs file exists, but the
-    cid object does not."""
 
     def __init__(self, message, errors=None):
         super().__init__(message)
@@ -90,6 +84,15 @@ class NonMatchingObjSize(Exception):
 class NonMatchingChecksum(Exception):
     """Custom exception thrown when verifying an object and the expected checksum
     does not match what has been calculated."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class RefsFileExistsButCidObjMissing(Exception):
+    """Custom exception thrown when pid and cid refs file exists, but the
+    cid object does not."""
 
     def __init__(self, message, errors=None):
         super().__init__(message)

--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -88,8 +88,6 @@ class HashStore(ABC):
         :param str checksum: Value of the checksum.
         :param str checksum_algorithm: Algorithm of the checksum.
         :param int expected_file_size: Size of the temporary file.
-
-        :return: bool - `True` if valid
         """
         raise NotImplementedError()
 

--- a/src/hashstore/hashstoreclient.py
+++ b/src/hashstore/hashstoreclient.py
@@ -256,7 +256,7 @@ class HashStoreClient:
         factory = HashStoreFactory()
 
         # Get HashStore from factory
-        if testflag is "knbvm":
+        if testflag:
             module_name = "filehashstore"
         else:
             module_name = "hashstore.filehashstore"

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -523,7 +523,7 @@ def test_write_to_tmp_file_and_get_hex_digests_checksum_and_additional_algo(stor
     path = test_dir + pid
     input_stream = io.open(path, "rb")
     additional_algo = "sha224"
-    additional_algo_checksum = (
+    additional_algo_checksum_correct = (
         "9b3a96f434f3c894359193a63437ef86fbd5a1a1a6cc37f1d5013ac1"
     )
     checksum_algo = "sha3_256"
@@ -538,7 +538,7 @@ def test_write_to_tmp_file_and_get_hex_digests_checksum_and_additional_algo(stor
     )
     input_stream.close()
     assert hex_digests.get("sha3_256") == checksum_correct
-    assert hex_digests.get("sha224") == additional_algo_checksum
+    assert hex_digests.get("sha224") == additional_algo_checksum_correct
 
 
 def test_write_to_tmp_file_and_get_hex_digests_checksum_and_additional_algo_duplicate(
@@ -831,6 +831,13 @@ def test_clean_algorithm(store):
     assert cleaned_algo_underscore == "sha256"
     assert cleaned_algo_hyphen == "sha256"
     assert cleaned_algo_other_hyphen == "sha3_256"
+
+
+def test_clean_algorithm_unsupported_algo(store):
+    """Check that algorithm values get formatted as expected."""
+    algorithm_unsupported = "mok22"
+    with pytest.raises(UnsupportedAlgorithm):
+        _ = store._clean_algorithm(algorithm_unsupported)
 
 
 def test_computehash(pids, store):

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -4,7 +4,11 @@ import io
 import os
 from pathlib import Path
 import pytest
-from hashstore.filehashstore import FileHashStore, NonMatchingObjSize
+from hashstore.filehashstore import (
+    FileHashStore,
+    NonMatchingChecksum,
+    NonMatchingObjSize,
+)
 
 # pylint: disable=W0212
 
@@ -322,7 +326,7 @@ def test_store_and_validate_data_with_incorrect_checksum(pids, store):
         algo = "sha224"
         algo_checksum = "badChecksumValue"
         path = test_dir + pid.replace("/", "_")
-        with pytest.raises(ValueError):
+        with pytest.raises(NonMatchingChecksum):
             store._store_and_validate_data(
                 pid, path, checksum=algo_checksum, checksum_algorithm=algo
             )
@@ -441,7 +445,7 @@ def test_move_and_get_checksums_raises_error_with_nonmatching_checksum(pids, sto
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         input_stream = io.open(path, "rb")
-        with pytest.raises(ValueError):
+        with pytest.raises(NonMatchingChecksum):
             # pylint: disable=W0212
             store._move_and_get_checksums(
                 pid,

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -8,6 +8,7 @@ from hashstore.filehashstore import (
     FileHashStore,
     NonMatchingChecksum,
     NonMatchingObjSize,
+    UnsupportedAlgorithm,
 )
 
 # pylint: disable=W0212
@@ -608,12 +609,12 @@ def test_write_to_tmp_file_and_get_hex_digests_with_unsupported_algorithm(pids, 
         path = test_dir + pid.replace("/", "_")
         input_stream = io.open(path, "rb")
         algo = "md2"
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             # pylint: disable=W0212
             _, _, _ = store._write_to_tmp_file_and_get_hex_digests(
                 input_stream, additional_algorithm=algo
             )
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             # pylint: disable=W0212
             _, _, _ = store._write_to_tmp_file_and_get_hex_digests(
                 input_stream, checksum_algorithm=algo

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -4,8 +4,8 @@ import io
 import os
 from pathlib import Path
 import pytest
-from hashstore.filehashstore import (
-    FileHashStore,
+from hashstore.filehashstore import FileHashStore
+from hashstore.filehashstore_exceptions import (
     NonMatchingChecksum,
     NonMatchingObjSize,
     UnsupportedAlgorithm,

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -4,7 +4,7 @@ import io
 import os
 from pathlib import Path
 import pytest
-from hashstore.filehashstore import FileHashStore
+from hashstore.filehashstore import FileHashStore, NonMatchingObjSize
 
 # pylint: disable=W0212
 
@@ -457,7 +457,7 @@ def test_move_and_get_checksums_incorrect_file_size(pids, store):
     """Test move and get checksum raises error with an incorrect file size."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
-        with pytest.raises(ValueError):
+        with pytest.raises(NonMatchingObjSize):
             path = test_dir + pid.replace("/", "_")
             input_stream = io.open(path, "rb")
             incorrect_file_size = 1000
@@ -719,7 +719,7 @@ def test_verify_object_information_incorrect_size(pids, store):
         hex_digests = object_metadata.hex_digests
         checksum = hex_digests.get(store.algorithm)
         checksum_algorithm = store.algorithm
-        with pytest.raises(ValueError):
+        with pytest.raises(NonMatchingObjSize):
             # pylint: disable=W0212
             store._verify_object_information(
                 None,

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -9,7 +9,7 @@ import threading
 import time
 import pytest
 
-from hashstore.filehashstore import (
+from hashstore.filehashstore_exceptions import (
     CidRefsDoesNotExist,
     NonMatchingChecksum,
     NonMatchingObjSize,

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -13,7 +13,6 @@ from hashstore.filehashstore import (
     CidRefsDoesNotExist,
     NonMatchingChecksum,
     NonMatchingObjSize,
-    PidObjectMetadataError,
     PidNotFoundInCidRefsFile,
     PidRefsDoesNotExist,
     RefsFileExistsButCidObjMissing,

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -16,6 +16,7 @@ from hashstore.filehashstore import (
     PidNotFoundInCidRefsFile,
     PidRefsDoesNotExist,
     RefsFileExistsButCidObjMissing,
+    UnsupportedAlgorithm,
 )
 
 # pylint: disable=W0212
@@ -178,7 +179,7 @@ def test_store_object_additional_algorithm_invalid(store):
     pid = "jtao.1700.1"
     path = test_dir + pid
     algorithm_not_in_list = "abc"
-    with pytest.raises(ValueError, match="Algorithm not supported"):
+    with pytest.raises(UnsupportedAlgorithm):
         store.store_object(pid, path, algorithm_not_in_list)
 
 
@@ -345,11 +346,26 @@ def test_store_object_checksum_incorrect_checksum(store):
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
+    algorithm_other = "sha224"
+    checksum_incorrect = (
+        "bbbb069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
+    )
+    with pytest.raises(NonMatchingChecksum):
+        store.store_object(
+            pid, path, checksum=checksum_incorrect, checksum_algorithm=algorithm_other
+        )
+
+
+def test_store_object_checksum_unsupported_checksum_algo(store):
+    """Test store object raises error when supplied with unsupported checksum algo."""
+    test_dir = "tests/testdata/"
+    pid = "jtao.1700.1"
+    path = test_dir + pid
     algorithm_other = "sha3_256"
     checksum_incorrect = (
         "bbbb069cd0116ba59638e5f3500bbff79b41d6184bc242bd71f5cbbb8cf484cf"
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(UnsupportedAlgorithm):
         store.store_object(
             pid, path, checksum=algorithm_other, checksum_algorithm=checksum_incorrect
         )
@@ -1304,7 +1320,7 @@ def test_get_hex_digest_pid_unsupported_algorithm(store):
     syspath.read_bytes()
     _object_metadata = store.store_object(pid, path)
     algorithm = "sm3"
-    with pytest.raises(ValueError):
+    with pytest.raises(UnsupportedAlgorithm):
         store.get_hex_digest(pid, algorithm)
 
 

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -11,6 +11,7 @@ import pytest
 
 from hashstore.filehashstore import (
     CidRefsDoesNotExist,
+    NonMatchingChecksum,
     NonMatchingObjSize,
     PidObjectMetadataError,
     PidNotFoundInCidRefsFile,
@@ -422,7 +423,7 @@ def test_store_object_duplicate_raises_error_with_bad_validation_data(pids, stor
     # Store first blob
     _object_metadata_one = store.store_object(pid, path)
     # Store second blob
-    with pytest.raises(PidObjectMetadataError):
+    with pytest.raises(NonMatchingChecksum):
         _object_metadata_two = store.store_object(
             pid, path, checksum="nonmatchingchecksum", checksum_algorithm="sha256"
         )

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -11,6 +11,7 @@ import pytest
 
 from hashstore.filehashstore import (
     CidRefsDoesNotExist,
+    NonMatchingObjSize,
     PidObjectMetadataError,
     PidNotFoundInCidRefsFile,
     PidRefsDoesNotExist,
@@ -448,7 +449,7 @@ def test_store_object_with_obj_file_size_incorrect(store, pids):
     for pid in pids.keys():
         obj_file_size = 1234
         path = test_dir + pid.replace("/", "_")
-        with pytest.raises(ValueError):
+        with pytest.raises(NonMatchingObjSize):
             store.store_object(pid, path, expected_object_size=obj_file_size)
 
 

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -184,7 +184,7 @@ def test_store_object_additional_algorithm_invalid(store):
 
 
 def test_store_object_additional_algorithm_hyphen_uppercase(pids, store):
-    """Test store object formats an additional algorithm in uppercase."""
+    """Test store object accepts an additional algo that's supported in uppercase."""
     test_dir = "tests/testdata/"
     entity = "objects"
     pid = "jtao.1700.1"
@@ -197,7 +197,7 @@ def test_store_object_additional_algorithm_hyphen_uppercase(pids, store):
 
 
 def test_store_object_additional_algorithm_hyphen_lowercase(pids, store):
-    """Test store object formats an with additional algorithm in lowercase."""
+    """Test store object accepts an with additional algo that's supported in lowercase."""
     test_dir = "tests/testdata/"
     entity = "objects"
     pid = "jtao.1700.1"
@@ -213,7 +213,7 @@ def test_store_object_additional_algorithm_hyphen_lowercase(pids, store):
 
 
 def test_store_object_additional_algorithm_underscore(pids, store):
-    """Test store object with formats an additional algorithm with underscore."""
+    """Test store object accepts an additional algo that's supported with underscore."""
     test_dir = "tests/testdata/"
     entity = "objects"
     pid = "jtao.1700.1"
@@ -269,7 +269,7 @@ def test_store_object_checksum_correct_and_additional_algo(store):
 
 
 def test_store_object_checksum_correct_and_additional_algo_duplicate(store):
-    """Test store object does not throw exception with duplicate algorithms."""
+    """Test store object does not throw exception with duplicate algorithms (de-dupes)."""
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
@@ -407,8 +407,8 @@ def test_store_object_duplicate_object_references_file_count(store):
 
 
 def test_store_object_duplicate_object_references_file_content(pids, store):
-    """Test that storing duplicate object but different pid creates the expected
-    amount of reference files."""
+    """Test that storing duplicate object but different pid updates the cid refs file
+    with the correct amount of pids."""
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
@@ -429,8 +429,8 @@ def test_store_object_duplicate_object_references_file_content(pids, store):
 
 
 def test_store_object_duplicate_raises_error_with_bad_validation_data(pids, store):
-    """Test store duplicate object throws ValueError when object exists
-    but the data to validate against is incorrect."""
+    """Test store duplicate object throws exception when the data to validate against
+    is incorrect."""
     test_dir = "tests/testdata/"
     pid = "jtao.1700.1"
     path = test_dir + pid
@@ -460,7 +460,7 @@ def test_store_object_with_obj_file_size(store, pids):
 
 
 def test_store_object_with_obj_file_size_incorrect(store, pids):
-    """Test store object throws exception with incorrect file sizes."""
+    """Test store object throws exception with incorrect file size."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         obj_file_size = 1234
@@ -470,7 +470,7 @@ def test_store_object_with_obj_file_size_incorrect(store, pids):
 
 
 def test_store_object_with_obj_file_size_non_integer(store, pids):
-    """Test store object throws exception with a non integer value (ex. a stirng)
+    """Test store object throws exception with a non integer value (ex. a string)
     as the file size."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
@@ -561,8 +561,8 @@ def test_store_object_threads_multiple_pids_one_cid_content(pids, store):
     with open(cid_refs_path, "r", encoding="utf8") as ref_file:
         # Confirm that pid is not currently already tagged
         for pid in ref_file:
-            number_of_pids_reffed += 1
-            assert pid.strip() in pid_list
+            if pid.strip() in pid_list:
+                number_of_pids_reffed += 1
 
     assert number_of_pids_reffed == 6
 
@@ -1102,7 +1102,7 @@ def test_delete_object_metadata_deleted(pids, store):
     assert store._count("metadata") == 0
 
 
-def test_delete_object_refs_files_deleted(pids, store):
+def test_delete_object_all_refs_files_deleted(pids, store):
     """Test delete_object successfully deletes refs files."""
     test_dir = "tests/testdata/"
     format_id = "http://ns.dataone.org/service/types/v2.0"
@@ -1236,6 +1236,24 @@ def test_delete_metadata_one_pid_multiple_metadata_documents(store):
     _metadata_cid4 = store.store_metadata(pid, syspath, format_id4)
     store.delete_metadata(pid)
     assert store._count(entity) == 0
+
+
+def test_delete_metadata_specific_pid_multiple_metadata_documents(store):
+    """Test delete_metadata for a pid with multiple metadata documents deletes
+    only the specified metadata file."""
+    test_dir = "tests/testdata/"
+    entity = "metadata"
+    pid = "jtao.1700.1"
+    filename = pid.replace("/", "_") + ".xml"
+    syspath = Path(test_dir) / filename
+    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id3 = "http://ns.dataone.org/service/types/v3.0"
+    format_id4 = "http://ns.dataone.org/service/types/v4.0"
+    _metadata_cid = store.store_metadata(pid, syspath, format_id)
+    _metadata_cid3 = store.store_metadata(pid, syspath, format_id3)
+    _metadata_cid4 = store.store_metadata(pid, syspath, format_id4)
+    store.delete_metadata(pid, format_id4)
+    assert store._count(entity) == 2
 
 
 def test_delete_metadata_does_not_exist(pids, store):

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import pytest
 
-from hashstore.filehashstore import PidAlreadyExistsError
+from hashstore.filehashstore import NonMatchingObjSize, PidAlreadyExistsError
 
 # pylint: disable=W0212
 
@@ -184,10 +184,8 @@ def test_verify_object_exception_incorrect_size(pids, store):
         checksum = object_metadata.hex_digests.get(store.algorithm)
         checksum_algorithm = store.algorithm
 
-        is_valid = store.verify_object(
-            object_metadata, checksum, checksum_algorithm, 1000
-        )
-        assert not is_valid
+        with pytest.raises(NonMatchingObjSize):
+            store.verify_object(object_metadata, checksum, checksum_algorithm, 1000)
 
         cid = object_metadata.cid
         cid = object_metadata.hex_digests[store.algorithm]

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -151,7 +151,7 @@ def test_tag_object_pid_refs_not_found_cid_refs_found(store):
 
 
 def test_verify_object(pids, store):
-    """Test verify_object succeeds given good arguments."""
+    """Test verify_object does not throw exception given good arguments."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
@@ -164,8 +164,19 @@ def test_verify_object(pids, store):
         )
 
 
+def test_verify_object_supported_other_algo_not_in_default(pids, store):
+    """Test verify_object throws exception when incorrect algorithm is supplied."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        object_metadata = store.store_object(data=path)
+        checksum = pids[pid]["sha224"]
+        expected_file_size = object_metadata.obj_size
+        store.verify_object(object_metadata, checksum, "sha224", expected_file_size)
+
+
 def test_verify_object_exception_incorrect_object_metadata_type(pids, store):
-    """Test verify_object returns false when incorrect object is given to
+    """Test verify_object throws exception when incorrect object is given to
     object_metadata arg."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
@@ -181,7 +192,7 @@ def test_verify_object_exception_incorrect_object_metadata_type(pids, store):
 
 
 def test_verify_object_exception_incorrect_size(pids, store):
-    """Test verify_object returns false when incorrect size is supplied."""
+    """Test verify_object throws exception when incorrect size is supplied."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
@@ -199,7 +210,7 @@ def test_verify_object_exception_incorrect_size(pids, store):
 
 
 def test_verify_object_exception_incorrect_checksum(pids, store):
-    """Test verify_object returns false when incorrect checksum is supplied."""
+    """Test verify_object throws exception when incorrect checksum is supplied."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
@@ -210,7 +221,7 @@ def test_verify_object_exception_incorrect_checksum(pids, store):
         expected_file_size = object_metadata.obj_size
 
         with pytest.raises(NonMatchingChecksum):
-            is_valid = store.verify_object(
+            store.verify_object(
                 object_metadata, "abc123", checksum_algorithm, expected_file_size
             )
 
@@ -221,7 +232,7 @@ def test_verify_object_exception_incorrect_checksum(pids, store):
 
 
 def test_verify_object_exception_incorrect_checksum_algo(pids, store):
-    """Test verify_object returns false when incorrect algorithm is supplied."""
+    """Test verify_object throws exception when unsupported algorithm is supplied."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
@@ -230,6 +241,18 @@ def test_verify_object_exception_incorrect_checksum_algo(pids, store):
         expected_file_size = object_metadata.obj_size
         with pytest.raises(UnsupportedAlgorithm):
             store.verify_object(object_metadata, checksum, "md2", expected_file_size)
+
+
+def test_verify_object_exception_supported_other_algo_bad_checksum(pids, store):
+    """Test verify_object throws exception when incorrect algorithm is supplied."""
+    test_dir = "tests/testdata/"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        object_metadata = store.store_object(data=path)
+        checksum = object_metadata.hex_digests.get(store.algorithm)
+        expected_file_size = object_metadata.obj_size
+        with pytest.raises(NonMatchingChecksum):
+            store.verify_object(object_metadata, checksum, "sha224", expected_file_size)
 
 
 def test_write_refs_file_ref_type_cid(store):

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -8,6 +8,7 @@ from hashstore.filehashstore import (
     NonMatchingChecksum,
     NonMatchingObjSize,
     PidAlreadyExistsError,
+    UnsupportedAlgorithm,
 )
 
 # pylint: disable=W0212
@@ -227,7 +228,7 @@ def test_verify_object_exception_incorrect_checksum_algo(pids, store):
         object_metadata = store.store_object(data=path)
         checksum = object_metadata.hex_digests.get(store.algorithm)
         expected_file_size = object_metadata.obj_size
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             store.verify_object(object_metadata, checksum, "md2", expected_file_size)
 
 

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -4,7 +4,11 @@ import os
 import shutil
 import pytest
 
-from hashstore.filehashstore import NonMatchingObjSize, PidAlreadyExistsError
+from hashstore.filehashstore import (
+    NonMatchingChecksum,
+    NonMatchingObjSize,
+    PidAlreadyExistsError,
+)
 
 # pylint: disable=W0212
 
@@ -204,10 +208,10 @@ def test_verify_object_exception_incorrect_checksum(pids, store):
         checksum_algorithm = store.algorithm
         expected_file_size = object_metadata.obj_size
 
-        is_valid = store.verify_object(
-            object_metadata, "abc123", checksum_algorithm, expected_file_size
-        )
-        assert not is_valid
+        with pytest.raises(NonMatchingChecksum):
+            is_valid = store.verify_object(
+                object_metadata, "abc123", checksum_algorithm, expected_file_size
+            )
 
         cid = object_metadata.cid
         cid = object_metadata.hex_digests[store.algorithm]

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import pytest
 
-from hashstore.filehashstore import (
+from hashstore.filehashstore_exceptions import (
     CidRefsContentError,
     CidRefsFileNotFound,
     NonMatchingChecksum,


### PR DESCRIPTION
**Summary of Changes:**
- `verify_object` now throws custom exceptions (more descriptive)
    - If called to verify an object with a checksum algorithm that is not part of the default list, will attempt to calculate the new checksum and verify it
- Refactored custom exception classes into their own module
- Deleted redundant code and cleaned up codebase & tests