### PR TITLE
Feature-112: `FileHashStore` Init Process Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ How to use HashStore client (command line app)
 # Step 0: Install hashstore via poetry to create an executable script
 $ poetry install
 
-# Step 1: Create a HashStore
+# Step 1: Create a HashStore at your desired store path (ex. /var/metacat/hashstore)
 $ hashstore /path/to/store/ -chs -dp=3 -wp=2 -ap=SHA-256 -nsp="http://www.ns.test/v1"
 
 # Get the checksum of a data object

--- a/README.md
+++ b/README.md
@@ -278,19 +278,19 @@ $ hashstore /path/to/store/ -findobject -pid=persistent_identifier
 $ hashstore /path/to/store/ -storeobject -pid=persistent_identifier -path=/path/to/object
 
 # Store a metadata object
-$ hashstore /path/to/store/ -storemetadata -pid=persistent_identifier -path=/path/to/metadata/object -formatid=http://ns.dataone.org/service/types/v2.0
+$ hashstore /path/to/store/ -storemetadata -pid=persistent_identifier -path=/path/to/metadata/object -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
 
 # Retrieve a data object
 $ hashstore /path/to/store/ -retrieveobject -pid=persistent_identifier
 
 # Retrieve a metadata object
-$ hashstore /path/to/store/ -retrievemetadata -pid=persistent_identifier -formatid=http://ns.dataone.org/service/types/v2.0
+$ hashstore /path/to/store/ -retrievemetadata -pid=persistent_identifier -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
 
 # Delete a data object
 $ hashstore /path/to/store/ -deleteobject -pid=persistent_identifier
 
 # Delete a metadata file
-$ hashstore /path/to/store/ -deletemetadata -pid=persistent_identifier -formatid=http://ns.dataone.org/service/types/v2.0
+$ hashstore /path/to/store/ -deletemetadata -pid=persistent_identifier -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
 ```
 
 ## License

--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -355,14 +355,19 @@ class FileHashStore(HashStore):
         else:
             if os.path.exists(prop_store_path):
                 # Check if HashStore exists and throw exception if found
-                if any(Path(prop_store_path).iterdir()):
+                subfolders = ["objects", "metadata", "refs"]
+                if any(
+                    os.path.isdir(os.path.join(prop_store_path, sub))
+                    for sub in subfolders
+                ):
                     exception_string = (
-                        "FileHashStore - HashStore directories and/or objects found at:"
-                        + f" {prop_store_path} but missing configuration file at: "
-                        + self.hashstore_configuration_yaml
+                        "FileHashStore - Unable to initialize HashStore. `hashstore.yaml` is not"
+                        + " present but conflicting HashStore directory exists. Please delete"
+                        + " '/objects', '/metadata' and/or '/refs' at the store path or supply"
+                        + " a new path."
                     )
                     logging.critical(exception_string)
-                    raise FileNotFoundError(exception_string)
+                    raise RuntimeError(exception_string)
 
     def _validate_properties(self, properties):
         """Validate a properties dictionary by checking if it contains all the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def init_props(tmp_path):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     return properties
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest overall configuration file for fixtures"""
+
 import pytest
 from hashstore.filehashstore import FileHashStore
 
@@ -16,8 +17,8 @@ def pytest_addoption(parser):
 @pytest.fixture(name="props")
 def init_props(tmp_path):
     """Properties to initialize HashStore."""
-    directory = tmp_path / "metacat"
-    directory.mkdir()
+    directory = tmp_path / "metacat" / "hashstore"
+    directory.mkdir(parents=True)
     hashstore_path = directory.as_posix()
     # Note, objects generated via tests are placed in a temporary folder
     # with the 'directory' parameter above appended

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -856,7 +856,7 @@ def test_get_store_path_object(store):
     # pylint: disable=W0212
     path_objects = store._get_store_path("objects")
     path_objects_string = str(path_objects)
-    assert path_objects_string.endswith("/metacat/objects")
+    assert path_objects_string.endswith("/metacat/hashstore/objects")
 
 
 def test_get_store_path_metadata(store):
@@ -864,7 +864,7 @@ def test_get_store_path_metadata(store):
     # pylint: disable=W0212
     path_metadata = store._get_store_path("metadata")
     path_metadata_string = str(path_metadata)
-    assert path_metadata_string.endswith("/metacat/metadata")
+    assert path_metadata_string.endswith("/metacat/hashstore/metadata")
 
 
 def test_get_store_path_refs(store):
@@ -872,7 +872,7 @@ def test_get_store_path_refs(store):
     # pylint: disable=W0212
     path_metadata = store._get_store_path("refs")
     path_metadata_string = str(path_metadata)
-    assert path_metadata_string.endswith("/metacat/refs")
+    assert path_metadata_string.endswith("/metacat/hashstore/refs")
 
 
 def test_exists_object_with_object_metadata_id(pids, store):

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -116,7 +116,7 @@ def test_init_with_existing_hashstore_mismatched_config_metadata_ns(store):
 
 
 def test_init_with_existing_hashstore_missing_yaml(store, pids):
-    """Test init with existing store raises FileNotFoundError when hashstore.yaml
+    """Test init with existing store raises RuntimeError when hashstore.yaml
     not found but objects exist."""
     test_dir = "tests/testdata/"
     for pid in pids.keys():
@@ -130,7 +130,7 @@ def test_init_with_existing_hashstore_missing_yaml(store, pids):
         "store_algorithm": "SHA-256",
         "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
     }
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(RuntimeError):
         FileHashStore(properties)
 
 

--- a/tests/test_filehashstore.py
+++ b/tests/test_filehashstore.py
@@ -35,7 +35,7 @@ def test_init_existing_store_incorrect_algorithm_format(store):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "sha256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(ValueError):
         FileHashStore(properties)
@@ -48,7 +48,7 @@ def test_init_existing_store_correct_algorithm_format(store):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     hashstore_instance = FileHashStore(properties)
     assert isinstance(hashstore_instance, FileHashStore)
@@ -67,7 +67,7 @@ def test_init_with_existing_hashstore_mismatched_config_depth(store):
         "store_depth": 1,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(ValueError):
         FileHashStore(properties)
@@ -81,7 +81,7 @@ def test_init_with_existing_hashstore_mismatched_config_width(store):
         "store_depth": 3,
         "store_width": 1,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(ValueError):
         FileHashStore(properties)
@@ -95,7 +95,7 @@ def test_init_with_existing_hashstore_mismatched_config_algo(store):
         "store_depth": 3,
         "store_width": 1,
         "store_algorithm": "SHA-512",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(ValueError):
         FileHashStore(properties)
@@ -128,7 +128,7 @@ def test_init_with_existing_hashstore_missing_yaml(store, pids):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(RuntimeError):
         FileHashStore(properties)
@@ -144,7 +144,7 @@ def test_load_properties(store):
     assert hashstore_yaml_dict.get("store_algorithm") == "SHA-256"
     assert (
         hashstore_yaml_dict.get("store_metadata_namespace")
-        == "http://ns.dataone.org/service/types/v2.0"
+        == "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     )
 
 
@@ -164,7 +164,7 @@ def test_validate_properties(store):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     # pylint: disable=W0212
     assert store._validate_properties(properties)
@@ -635,7 +635,7 @@ def test_put_metadata_with_path(pids, store):
     """Test _put_metadata with path object for the path arg."""
     entity = "metadata"
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
@@ -648,7 +648,7 @@ def test_put_metadata_with_string(pids, store):
     """Test_put metadata with string for the path arg."""
     entity = "metadata"
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = str(Path(test_dir) / filename)
@@ -660,7 +660,7 @@ def test_put_metadata_with_string(pids, store):
 def test_put_metadata_cid(pids, store):
     """Test put metadata returns correct id."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         metadata_document_name = store._computehash(pid + format_id)
         filename = pid.replace("/", "_") + ".xml"
@@ -901,7 +901,7 @@ def test_exists_metadata_files_path(pids, store):
     """Test exists works as expected for metadata."""
     test_dir = "tests/testdata/"
     entity = "metadata"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
@@ -1001,7 +1001,7 @@ def test_get_real_path_with_metadata_id(store, pids):
     """Test get_real_path returns absolute path given a metadata id."""
     entity = "metadata"
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
@@ -1068,7 +1068,7 @@ def test_resolve_path_objects(pids, store):
 def test_resolve_path_metadata(pids, store):
     """Confirm resolve path returns correct metadata path."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -796,7 +796,7 @@ def test_store_metadata(pids, store):
     """Test store metadata."""
     test_dir = "tests/testdata/"
     entity = "metadata"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
@@ -821,7 +821,7 @@ def test_store_metadata_one_pid_multiple_docs_correct_location(store):
     syspath = Path(test_dir) / filename
     metadata_directory = store._computehash(pid)
     rel_path = "/".join(store._shard(metadata_directory))
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     format_id3 = "http://ns.dataone.org/service/types/v3.0"
     format_id4 = "http://ns.dataone.org/service/types/v4.0"
     metadata_cid = store.store_metadata(pid, syspath, format_id)
@@ -842,7 +842,7 @@ def test_store_metadata_one_pid_multiple_docs_correct_location(store):
 def test_store_metadata_default_format_id(pids, store):
     """Test store metadata returns expected id when storing with default format_id."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
@@ -861,7 +861,7 @@ def test_store_metadata_files_string(pids, store):
     """Test store metadata with a string object to the metadata."""
     test_dir = "tests/testdata/"
     entity = "metadata"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath_string = str(Path(test_dir) / filename)
@@ -874,7 +874,7 @@ def test_store_metadata_files_input_stream(pids, store):
     """Test store metadata with an input stream to metadata."""
     test_dir = "tests/testdata/"
     entity = "metadata"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath_string = str(Path(test_dir) / filename)
@@ -887,7 +887,7 @@ def test_store_metadata_files_input_stream(pids, store):
 def test_store_metadata_pid_empty(store):
     """Test store metadata raises error with an empty string as the pid."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = ""
     filename = pid.replace("/", "_") + ".xml"
     syspath_string = str(Path(test_dir) / filename)
@@ -898,7 +898,7 @@ def test_store_metadata_pid_empty(store):
 def test_store_metadata_pid_empty_spaces(store):
     """Test store metadata raises error with empty spaces as the pid."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "   "
     filename = pid.replace("/", "_") + ".xml"
     syspath_string = str(Path(test_dir) / filename)
@@ -920,7 +920,7 @@ def test_store_metadata_pid_format_id_spaces(store):
 def test_store_metadata_metadata_empty(store):
     """Test store metadata raises error with empty spaces as the metadata path."""
     pid = "jtao.1700.1"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     syspath_string = "   "
     with pytest.raises(TypeError):
         store.store_metadata(pid, syspath_string, format_id)
@@ -929,7 +929,7 @@ def test_store_metadata_metadata_empty(store):
 def test_store_metadata_metadata_none(store):
     """Test store metadata raises error with empty None metadata path."""
     pid = "jtao.1700.1"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     syspath_string = None
     with pytest.raises(TypeError):
         store.store_metadata(pid, syspath_string, format_id)
@@ -938,7 +938,7 @@ def test_store_metadata_metadata_none(store):
 def test_store_metadata_metadata_path(pids, store):
     """Test store metadata returns expected path to metadata document."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -953,7 +953,7 @@ def test_store_metadata_thread_lock(store):
     """Test store metadata thread lock."""
     test_dir = "tests/testdata/"
     entity = "metadata"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "jtao.1700.1"
     path = test_dir + pid
     filename = pid + ".xml"
@@ -979,7 +979,7 @@ def test_store_metadata_thread_lock(store):
 def test_retrieve_object(pids, store):
     """Test retrieve_object returns a stream to the correct object data."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1010,7 +1010,7 @@ def test_retrieve_object_pid_invalid(store):
 def test_retrieve_metadata(store):
     """Test retrieve_metadata returns a stream to the correct metadata."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "jtao.1700.1"
     path = test_dir + pid
     filename = pid + ".xml"
@@ -1042,7 +1042,7 @@ def test_retrieve_metadata_default_format_id(store):
 
 def test_retrieve_metadata_bytes_pid_invalid(store):
     """Test retrieve_metadata raises error when supplied with bad pid."""
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "jtao.1700.1"
     pid_does_not_exist = pid + "test"
     with pytest.raises(ValueError):
@@ -1051,7 +1051,7 @@ def test_retrieve_metadata_bytes_pid_invalid(store):
 
 def test_retrieve_metadata_bytes_pid_empty(store):
     """Test retrieve_metadata raises error when supplied with empty pid."""
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "    "
     with pytest.raises(ValueError):
         store.retrieve_metadata(pid, format_id)
@@ -1076,7 +1076,7 @@ def test_retrieve_metadata_format_id_empty_spaces(store):
 def test_delete_object_object_deleted(pids, store):
     """Test delete_object successfully deletes object."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1091,7 +1091,7 @@ def test_delete_object_metadata_deleted(pids, store):
     """Test delete_object successfully deletes relevant metadata
     files and refs files."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1105,7 +1105,7 @@ def test_delete_object_metadata_deleted(pids, store):
 def test_delete_object_all_refs_files_deleted(pids, store):
     """Test delete_object successfully deletes refs files."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1120,7 +1120,7 @@ def test_delete_object_all_refs_files_deleted(pids, store):
 def test_delete_object_pid_refs_file_deleted(pids, store):
     """Test delete_object deletes the associated pid refs file for the object."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1135,7 +1135,7 @@ def test_delete_object_pid_refs_file_deleted(pids, store):
 def test_delete_object_cid_refs_file_deleted(pids, store):
     """Test delete_object deletes the associated cid refs file for the object."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1178,7 +1178,7 @@ def test_delete_object_idtype_cid_refs_file_exists(pids, store):
     """Test delete_object does not delete object if a cid refs file still exists."""
     test_dir = "tests/testdata/"
     entity = "objects"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1209,7 +1209,7 @@ def test_delete_metadata(pids, store):
     """Test delete_metadata successfully deletes metadata."""
     test_dir = "tests/testdata/"
     entity = "metadata"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         filename = pid.replace("/", "_") + ".xml"
@@ -1228,7 +1228,7 @@ def test_delete_metadata_one_pid_multiple_metadata_documents(store):
     pid = "jtao.1700.1"
     filename = pid.replace("/", "_") + ".xml"
     syspath = Path(test_dir) / filename
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     format_id3 = "http://ns.dataone.org/service/types/v3.0"
     format_id4 = "http://ns.dataone.org/service/types/v4.0"
     _metadata_cid = store.store_metadata(pid, syspath, format_id)
@@ -1246,7 +1246,7 @@ def test_delete_metadata_specific_pid_multiple_metadata_documents(store):
     pid = "jtao.1700.1"
     filename = pid.replace("/", "_") + ".xml"
     syspath = Path(test_dir) / filename
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     format_id3 = "http://ns.dataone.org/service/types/v3.0"
     format_id4 = "http://ns.dataone.org/service/types/v4.0"
     _metadata_cid = store.store_metadata(pid, syspath, format_id)
@@ -1259,7 +1259,7 @@ def test_delete_metadata_specific_pid_multiple_metadata_documents(store):
 def test_delete_metadata_does_not_exist(pids, store):
     """Test delete_metadata does not throw exception when called to delete
     metadata that does not exist."""
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         store.delete_metadata(pid, format_id)
 
@@ -1280,7 +1280,7 @@ def test_delete_metadata_default_format_id(store, pids):
 
 def test_delete_metadata_pid_empty(store):
     """Test delete_object raises error when empty pid supplied."""
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "    "
     with pytest.raises(ValueError):
         store.delete_metadata(pid, format_id)
@@ -1288,7 +1288,7 @@ def test_delete_metadata_pid_empty(store):
 
 def test_delete_metadata_pid_none(store):
     """Test delete_object raises error when pid is 'None'."""
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = None
     with pytest.raises(ValueError):
         store.delete_metadata(pid, format_id)
@@ -1305,7 +1305,7 @@ def test_delete_metadata_format_id_empty(store):
 def test_get_hex_digest(store):
     """Test get_hex_digest for expected value."""
     test_dir = "tests/testdata/"
-    format_id = "http://ns.dataone.org/service/types/v2.0"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     pid = "jtao.1700.1"
     path = test_dir + pid
     filename = pid + ".xml"

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -54,7 +54,7 @@ def test_factory_get_hashstore_filehashstore_unsupported_algorithm(factory):
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "MD2",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(ValueError):
         factory.get_hashstore(module_name, class_name, properties)
@@ -70,7 +70,7 @@ def test_factory_get_hashstore_filehashstore_incorrect_algorithm_format(factory)
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "dou_algo",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(ValueError):
         factory.get_hashstore(module_name, class_name, properties)
@@ -90,7 +90,7 @@ def test_factory_get_hashstore_filehashstore_conflicting_obj_dir(factory, tmp_pa
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(RuntimeError):
         factory.get_hashstore(module_name, class_name, properties)
@@ -112,7 +112,7 @@ def test_factory_get_hashstore_filehashstore_conflicting_metadata_dir(
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(RuntimeError):
         factory.get_hashstore(module_name, class_name, properties)
@@ -132,7 +132,7 @@ def test_factory_get_hashstore_filehashstore_conflicting_refs_dir(factory, tmp_p
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
     with pytest.raises(RuntimeError):
         factory.get_hashstore(module_name, class_name, properties)
@@ -152,7 +152,7 @@ def test_factory_get_hashstore_filehashstore_nonconflicting_dir(factory, tmp_pat
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "SHA-256",
-        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+        "store_metadata_namespace": "https://ns.dataone.org/service/types/v2.0#SystemMetadata",
     }
 
     factory.get_hashstore(module_name, class_name, properties)

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -76,6 +76,88 @@ def test_factory_get_hashstore_filehashstore_incorrect_algorithm_format(factory)
         factory.get_hashstore(module_name, class_name, properties)
 
 
+def test_factory_get_hashstore_filehashstore_conflicting_obj_dir(factory, tmp_path):
+    """Check factory raises exception when existing `/objects` directory exists."""
+    module_name = "hashstore.filehashstore"
+    class_name = "FileHashStore"
+
+    directory = tmp_path / "douhs" / "objects"
+    directory.mkdir(parents=True)
+    douhspath = (tmp_path / "douhs").as_posix()
+
+    properties = {
+        "store_path": douhspath,
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "SHA-256",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    with pytest.raises(RuntimeError):
+        factory.get_hashstore(module_name, class_name, properties)
+
+
+def test_factory_get_hashstore_filehashstore_conflicting_metadata_dir(
+    factory, tmp_path
+):
+    """Check factory raises exception when existing `/metadata` directory exists."""
+    module_name = "hashstore.filehashstore"
+    class_name = "FileHashStore"
+
+    directory = tmp_path / "douhs" / "metadata"
+    directory.mkdir(parents=True)
+    douhspath = (tmp_path / "douhs").as_posix()
+
+    properties = {
+        "store_path": douhspath,
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "SHA-256",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    with pytest.raises(RuntimeError):
+        factory.get_hashstore(module_name, class_name, properties)
+
+
+def test_factory_get_hashstore_filehashstore_conflicting_refs_dir(factory, tmp_path):
+    """Check factory raises exception when existing `/refs` directory exists."""
+    module_name = "hashstore.filehashstore"
+    class_name = "FileHashStore"
+
+    directory = tmp_path / "douhs" / "refs"
+    directory.mkdir(parents=True)
+    douhspath = (tmp_path / "douhs").as_posix()
+
+    properties = {
+        "store_path": douhspath,
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "SHA-256",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+    with pytest.raises(RuntimeError):
+        factory.get_hashstore(module_name, class_name, properties)
+
+
+def test_factory_get_hashstore_filehashstore_nonconflicting_dir(factory, tmp_path):
+    """Check factory does not raise exception when existing non-conflicting directory exists."""
+    module_name = "hashstore.filehashstore"
+    class_name = "FileHashStore"
+
+    directory = tmp_path / "douhs" / "other"
+    directory.mkdir(parents=True)
+    douhspath = (tmp_path / "douhs").as_posix()
+
+    properties = {
+        "store_path": douhspath,
+        "store_depth": 3,
+        "store_width": 2,
+        "store_algorithm": "SHA-256",
+        "store_metadata_namespace": "http://ns.dataone.org/service/types/v2.0",
+    }
+
+    factory.get_hashstore(module_name, class_name, properties)
+
+
 def test_objectmetadata():
     """Test ObjectMetadata class returns correct values via dot notation."""
     pid = "hashstore"

--- a/tests/test_hashstore.py
+++ b/tests/test_hashstore.py
@@ -1,4 +1,5 @@
 """Test module for HashStore's HashStoreFactory and ObjectMetadata class."""
+
 import os
 import pytest
 from hashstore.hashstore import ObjectMetadata, HashStoreFactory
@@ -49,7 +50,7 @@ def test_factory_get_hashstore_filehashstore_unsupported_algorithm(factory):
     class_name = "FileHashStore"
 
     properties = {
-        "store_path": os.getcwd() + "/metacat/test",
+        "store_path": os.getcwd() + "/metacat/hashstore",
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "MD2",
@@ -65,7 +66,7 @@ def test_factory_get_hashstore_filehashstore_incorrect_algorithm_format(factory)
     class_name = "FileHashStore"
 
     properties = {
-        "store_path": os.getcwd() + "/metacat/test",
+        "store_path": os.getcwd() + "/metacat/hashstore",
         "store_depth": 3,
         "store_width": 2,
         "store_algorithm": "dou_algo",

--- a/tests/test_hashstore_client.py
+++ b/tests/test_hashstore_client.py
@@ -142,7 +142,7 @@ def test_store_metadata(capsys, store, pids):
     """Test storing metadata to HashStore through client."""
     client_directory = os.getcwd() + "/src/hashstore"
     test_dir = "tests/testdata/"
-    namespace = "http://ns.dataone.org/service/types/v2.0"
+    namespace = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     entity = "metadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
@@ -223,7 +223,7 @@ def test_retrieve_metadata(capsys, pids, store):
     """Test retrieving metadata from a HashStore through client."""
     client_directory = os.getcwd() + "/src/hashstore"
     test_dir = "tests/testdata/"
-    namespace = "http://ns.dataone.org/service/types/v2.0"
+    namespace = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename
@@ -293,7 +293,7 @@ def test_delete_metadata(pids, store):
     """Test deleting metadata from a HashStore through client."""
     client_directory = os.getcwd() + "/src/hashstore"
     test_dir = "tests/testdata/"
-    namespace = "http://ns.dataone.org/service/types/v2.0"
+    namespace = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
     for pid in pids.keys():
         filename = pid.replace("/", "_") + ".xml"
         syspath = Path(test_dir) / filename


### PR DESCRIPTION
Summary of Changes:
- `filehashstore` now throws exception during init process if the given path is missing the `hashstore.yaml` config file and `/objects`, `/metadata` or `/refs` exists. Other folders or files are allowed to exist at the supplied location
- Updated pytests and references to old placeholder sysmeta namespace value to new designated value
- Updated README.md