### PR TITLE
Feature-113: `find_object` Update

### DIFF
--- a/src/hashstore/hashstore.py
+++ b/src/hashstore/hashstore.py
@@ -99,7 +99,12 @@ class HashStore(ABC):
 
         :param str pid: Authority-based or persistent identifier of the object.
 
-        :return: str - Content identifier of the object.
+        :return: obj_info_dict (dict):
+            - cid: content identifier
+            - cid_object_path: path to the object
+            - cid_refs_path: path to the cid refs file
+            - pid_refs_path: path to the pid refs file
+            - sysmeta_path: path to the sysmeta file
         """
         raise NotImplementedError()
 

--- a/src/hashstore/hashstoreclient.py
+++ b/src/hashstore/hashstoreclient.py
@@ -850,8 +850,17 @@ def main():
         if pid is None:
             raise ValueError("'-pid' option is required")
         # Find the content identifier of the object
-        cid = hashstore_c.hashstore.find_object(pid)
-        print(f"Content identifier: {cid}")
+        object_info_dict = hashstore_c.hashstore.find_object(pid)
+        cid = object_info_dict.get("cid")
+        cid_object_path = object_info_dict.get("cid")
+        cid_refs_path = object_info_dict.get("cid_refs_path")
+        pid_refs_path = object_info_dict.get("pid_refs_path")
+        sysmeta_path = object_info_dict.get("sysmeta_path")
+        print(f"Content identifier:\n{cid}")
+        print(f"Cid Object Path:\n:{cid_object_path}")
+        print(f"Cid Reference File Path:\n:{cid_refs_path}")
+        print(f"Pid Reference File Path:\n:{pid_refs_path}")
+        print(f"Sysmeta Path:\n:{sysmeta_path}")
 
     elif getattr(args, "client_storeobject"):
         if pid is None:

--- a/src/hashstore/hashstoreclient.py
+++ b/src/hashstore/hashstoreclient.py
@@ -852,7 +852,7 @@ def main():
         # Find the content identifier of the object
         object_info_dict = hashstore_c.hashstore.find_object(pid)
         cid = object_info_dict.get("cid")
-        cid_object_path = object_info_dict.get("cid")
+        cid_object_path = object_info_dict.get("cid_object_path")
         cid_refs_path = object_info_dict.get("cid_refs_path")
         pid_refs_path = object_info_dict.get("pid_refs_path")
         sysmeta_path = object_info_dict.get("sysmeta_path")

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -718,8 +718,8 @@ def test_find_object(pids, store):
     for pid in pids.keys():
         path = test_dir + pid.replace("/", "_")
         object_metadata = store.store_object(pid, path)
-        cid = store.find_object(pid)
-        assert cid == object_metadata.hex_digests.get("sha256")
+        obj_info_dict = store.find_object(pid)
+        assert obj_info_dict.get("cid") == object_metadata.hex_digests.get("sha256")
 
 
 def test_find_object_refs_exist_but_obj_not_found(pids, store):
@@ -729,7 +729,7 @@ def test_find_object_refs_exist_but_obj_not_found(pids, store):
         path = test_dir + pid.replace("/", "_")
         store.store_object(pid, path)
 
-        cid = store.find_object(pid)
+        cid = store.find_object(pid).get("cid")
         obj_path = store._resolve_path("objects", cid)
         os.remove(obj_path)
 

--- a/tests/test_hashstore_client.py
+++ b/tests/test_hashstore_client.py
@@ -81,7 +81,7 @@ def test_get_checksum(capsys, store, pids):
 
 
 def test_find_object_sysmeta_does_not_exist(capsys, store, pids):
-    """Test find_object returns a content identifier if it exists."""
+    """Test client's find_object prints the required values when sysmeta does not exist."""
     client_directory = os.getcwd() + "/src/hashstore"
     test_dir = "tests/testdata/"
     for pid in pids.keys():
@@ -125,7 +125,7 @@ def test_find_object_sysmeta_does_not_exist(capsys, store, pids):
 
 
 def test_find_object_sysmeta_exists(capsys, store, pids):
-    """Test find_object returns a content identifier if it exists."""
+    """Test client's find_object prints the required values when sysmeta exists"""
     client_directory = os.getcwd() + "/src/hashstore"
     test_dir = "tests/testdata/"
     format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"

--- a/tests/test_hashstore_client.py
+++ b/tests/test_hashstore_client.py
@@ -80,7 +80,7 @@ def test_get_checksum(capsys, store, pids):
         assert capsystext == expected_output
 
 
-def test_find_object(capsys, store, pids):
+def test_find_object_sysmeta_does_not_exist(capsys, store, pids):
     """Test find_object returns a content identifier if it exists."""
     client_directory = os.getcwd() + "/src/hashstore"
     test_dir = "tests/testdata/"
@@ -88,6 +88,55 @@ def test_find_object(capsys, store, pids):
         path = test_dir + pid.replace("/", "_")
         object_metadata = store.store_object(pid, path)
         cid = object_metadata.cid
+
+        client_module_path = f"{client_directory}/client.py"
+        test_store = store.root
+        find_object_opt = "-findobject"
+        client_pid_arg = f"-pid={pid}"
+        chs_args = [
+            client_module_path,
+            test_store,
+            find_object_opt,
+            client_pid_arg,
+        ]
+
+        # Add file path of HashStore to sys so modules can be discovered
+        sys.path.append(client_directory)
+        # Manually change sys args to simulate command line arguments
+        sys.argv = chs_args
+        hashstoreclient.main()
+
+        object_info_dict = store.find_object(pid)
+        cid = object_info_dict.get("cid")
+        cid_object_path = object_info_dict.get("cid_object_path")
+        cid_refs_path = object_info_dict.get("cid_refs_path")
+        pid_refs_path = object_info_dict.get("pid_refs_path")
+        sysmeta_path = object_info_dict.get("sysmeta_path")
+
+        capsystext = capsys.readouterr().out
+        expected_output = (
+            f"Content identifier:\n{cid}\n"
+            + f"Cid Object Path:\n:{cid_object_path}\n"
+            + f"Cid Reference File Path:\n:{cid_refs_path}\n"
+            + f"Pid Reference File Path:\n:{pid_refs_path}\n"
+            + f"Sysmeta Path:\n:{sysmeta_path}\n"
+        )
+        assert capsystext == expected_output
+
+
+def test_find_object_sysmeta_exists(capsys, store, pids):
+    """Test find_object returns a content identifier if it exists."""
+    client_directory = os.getcwd() + "/src/hashstore"
+    test_dir = "tests/testdata/"
+    format_id = "https://ns.dataone.org/service/types/v2.0#SystemMetadata"
+    for pid in pids.keys():
+        path = test_dir + pid.replace("/", "_")
+        object_metadata = store.store_object(pid, path)
+        cid = object_metadata.cid
+
+        filename = pid.replace("/", "_") + ".xml"
+        syspath = Path(test_dir) / filename
+        store.store_metadata(pid, syspath, format_id)
 
         client_module_path = f"{client_directory}/client.py"
         test_store = store.root

--- a/tests/test_hashstore_client.py
+++ b/tests/test_hashstore_client.py
@@ -108,7 +108,7 @@ def test_find_object(capsys, store, pids):
 
         object_info_dict = store.find_object(pid)
         cid = object_info_dict.get("cid")
-        cid_object_path = object_info_dict.get("cid")
+        cid_object_path = object_info_dict.get("cid_object_path")
         cid_refs_path = object_info_dict.get("cid_refs_path")
         pid_refs_path = object_info_dict.get("pid_refs_path")
         sysmeta_path = object_info_dict.get("sysmeta_path")

--- a/tests/test_hashstore_client.py
+++ b/tests/test_hashstore_client.py
@@ -106,8 +106,21 @@ def test_find_object(capsys, store, pids):
         sys.argv = chs_args
         hashstoreclient.main()
 
+        object_info_dict = store.find_object(pid)
+        cid = object_info_dict.get("cid")
+        cid_object_path = object_info_dict.get("cid")
+        cid_refs_path = object_info_dict.get("cid_refs_path")
+        pid_refs_path = object_info_dict.get("pid_refs_path")
+        sysmeta_path = object_info_dict.get("sysmeta_path")
+
         capsystext = capsys.readouterr().out
-        expected_output = f"Content identifier: {cid}\n"
+        expected_output = (
+            f"Content identifier:\n{cid}\n"
+            + f"Cid Object Path:\n:{cid_object_path}\n"
+            + f"Cid Reference File Path:\n:{cid_refs_path}\n"
+            + f"Pid Reference File Path:\n:{pid_refs_path}\n"
+            + f"Sysmeta Path:\n:{sysmeta_path}\n"
+        )
         assert capsystext == expected_output
 
 


### PR DESCRIPTION
Summary of Changes:
- `find_object` now returns a dictionary with the following keys:
    - cid
    - cid_object_path
    - cid_refs_path
    - pid_refs_path
    - sysmeta_path
- Revised code that calls `find_object`, including the `hashstoreclient`, `get_hex_digest` method and `delete_object` method
- Updates to `hashstore` interface & pytests