### PR TITLE
Feature-114: `tag_object` Update for Existing HashStore Files

### DIFF
--- a/src/hashstore/filehashstore.py
+++ b/src/hashstore/filehashstore.py
@@ -18,6 +18,7 @@ from hashstore.filehashstore_exceptions import (
     CidRefsContentError,
     CidRefsDoesNotExist,
     CidRefsFileNotFound,
+    HashStoreRefsAlreadyExists,
     NonMatchingChecksum,
     NonMatchingObjSize,
     PidAlreadyExistsError,
@@ -639,7 +640,12 @@ class FileHashStore(HashStore):
                     cid_refs_path,
                     "Refs file already exists, verifying.",
                 )
-                return True
+                error_msg = (
+                    f"FileHashStore - tag_object: Object with cid: {cid}"
+                    + f" already exists and is tagged with pid: {pid}"
+                )
+                logging.error(error_msg)
+                raise HashStoreRefsAlreadyExists(error_msg)
             elif os.path.exists(pid_refs_path) and not os.path.exists(cid_refs_path):
                 debug_msg = (
                     f"FileHashStore - tag_object: pid refs file exists ({pid_refs_path})"

--- a/src/hashstore/filehashstore_exceptions.py
+++ b/src/hashstore/filehashstore_exceptions.py
@@ -99,6 +99,14 @@ class RefsFileExistsButCidObjMissing(Exception):
         self.errors = errors
 
 
+class HashStoreRefsAlreadyExists(Exception):
+    """Custom exception thrown when called to tag an object that is already tagged appropriately."""
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
 class UnsupportedAlgorithm(Exception):
     """Custom exception thrown when a given algorithm is not supported in HashStore for
     calculating hashes/checksums, as the default store algo and/or other operations."""

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -11,7 +11,6 @@ import pytest
 
 from hashstore.filehashstore_exceptions import (
     CidRefsDoesNotExist,
-    HashStoreRefsAlreadyExists,
     NonMatchingChecksum,
     NonMatchingObjSize,
     PidNotFoundInCidRefsFile,
@@ -501,6 +500,7 @@ def test_store_object_duplicates_threads(pids, store):
     def store_object_wrapper(obj_pid, obj_path):
         try:
             store.store_object(obj_pid, obj_path)  # Call store_object inside the thread
+        # pylint: disable=W0718
         except Exception as e:
             assert type(e).__name__ == "HashStoreRefsAlreadyExists"
 

--- a/tests/test_filehashstore_interface.py
+++ b/tests/test_filehashstore_interface.py
@@ -11,6 +11,7 @@ import pytest
 
 from hashstore.filehashstore_exceptions import (
     CidRefsDoesNotExist,
+    HashStoreRefsAlreadyExists,
     NonMatchingChecksum,
     NonMatchingObjSize,
     PidNotFoundInCidRefsFile,
@@ -498,7 +499,10 @@ def test_store_object_duplicates_threads(pids, store):
     entity = "objects"
 
     def store_object_wrapper(obj_pid, obj_path):
-        store.store_object(obj_pid, obj_path)  # Call store_object inside the thread
+        try:
+            store.store_object(obj_pid, obj_path)  # Call store_object inside the thread
+        except Exception as e:
+            assert type(e).__name__ == "HashStoreRefsAlreadyExists"
 
     thread1 = Thread(target=store_object_wrapper, args=(pid, path))
     thread2 = Thread(target=store_object_wrapper, args=(pid, path))

--- a/tests/test_filehashstore_references.py
+++ b/tests/test_filehashstore_references.py
@@ -7,6 +7,7 @@ import pytest
 from hashstore.filehashstore_exceptions import (
     CidRefsContentError,
     CidRefsFileNotFound,
+    HashStoreRefsAlreadyExists,
     NonMatchingChecksum,
     NonMatchingObjSize,
     PidAlreadyExistsError,
@@ -86,7 +87,9 @@ def test_tag_object_pid_refs_found_cid_refs_found(pids, store):
         object_metadata = store.store_object(None, path)
         cid = object_metadata.cid
         store.tag_object(pid, cid)
-        store.tag_object(pid, cid)
+
+        with pytest.raises(HashStoreRefsAlreadyExists):
+            store.tag_object(pid, cid)
 
         cid_refs_file_path = store._resolve_path("cid", object_metadata.cid)
         line_count = 0


### PR DESCRIPTION
**Summary of Changes:**
- When `tag_object` is called explicitly by the user or the `store_object` method, a custom exception `HashStoreRefsAlreadyExists` is thrown if the refs files already exist for the given `pid` and `cid`